### PR TITLE
CMake definitions and format rearrangement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,10 @@ jobs:
           -D SFIZZ_JACK=OFF
           -D SFIZZ_RENDER=OFF
           -D SFIZZ_SHARED=OFF
-          -D SFIZZ_LV2=ON
-          -D SFIZZ_LV2_UI=ON
-          -D SFIZZ_PUREDATA=ON
-          -D SFIZZ_VST=ON
+          -D PLUGIN_LV2=ON
+          -D PLUGIN_LV2_UI=ON
+          -D PLUGIN_PUREDATA=ON
+          -D PLUGIN_VST3=ON
         )
         cmake "${options[@]}"
     - name: Build
@@ -106,10 +106,10 @@ jobs:
           -D CMAKE_BUILD_TYPE=${{ env.build_type }}
           -D CMAKE_CXX_STANDARD=17
           -D SFIZZ_SHARED=OFF
-          -D SFIZZ_AU=ON
-          -D SFIZZ_LV2=ON
-          -D SFIZZ_LV2_UI=ON
-          -D SFIZZ_VST=ON
+          -D PLUGIN_AU=ON
+          -D PLUGIN_LV2=ON
+          -D PLUGIN_LV2_UI=ON
+          -D PLUGIN_VST3=ON
         )
         if [[ ${{ github.ref_type }} == 'branch' ]]; then
           options=(
@@ -182,9 +182,9 @@ jobs:
           -S "${Env:GITHUB_WORKSPACE}" `
           -D CMAKE_BUILD_TYPE=${{ env.build_type }} `
           -D CMAKE_CXX_STANDARD=17 `
-          -D SFIZZ_LV2=ON `
-          -D SFIZZ_PUREDATA=ON `
-          -D SFIZZ_VST=ON `
+          -D PLUGIN_LV2=ON `
+          -D PLUGIN_PUREDATA=ON `
+          -D PLUGIN_VST3=ON `
     - name: Build
       working-directory: ${{ runner.workspace }}
       run: cmake --build build --config ${{ env.build_type }} --verbose -j 2
@@ -301,8 +301,8 @@ jobs:
           -D ENABLE_LTO=OFF
           -D SFIZZ_STATIC_DEPENDENCIES=ON
           -D SFIZZ_JACK=OFF
-          -D SFIZZ_PUREDATA=ON
-          -D SFIZZ_VST=ON
+          -D PLUGIN_PUREDATA=ON
+          -D PLUGIN_VST3=ON
         )
         ${{ matrix.platform }}-w64-mingw32-cmake "${options[@]}"
     - name: Build
@@ -353,8 +353,8 @@ jobs:
           -D PROJECT_SYSTEM_PROCESSOR=armv7-a \
           -D CMAKE_BUILD_TYPE=Release \
           -D SFIZZ_JACK=OFF \
-          -D SFIZZ_VST=OFF \
-          -D SFIZZ_LV2_UI=OFF
+          -D PLUGIN_VST3=OFF \
+          -D PLUGIN_LV2_UI=OFF
     - name: Build
       shell: bash
       working-directory: ${{ runner.workspace }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,34 @@
-if (WIN32)
-    cmake_minimum_required (VERSION 3.15)
+if(WIN32)
+    cmake_minimum_required(VERSION 3.15)
     cmake_policy(SET CMP0091 NEW)
 else()
     # FIXME: The old JPC fork of mod-plugin-builder image used in CI requires 3.5.
     #        The current upstream one needs a different configuration.
-    #        Minimum required to use SFIZZ_USE_SYSTEM_ABSEIL is 3.11,
-    #        see library/cmake/SfizzDeps.cmake at line 70.
-    cmake_minimum_required(VERSION 3.11)
+    # Minimum required to use SFIZZ_USE_SYSTEM_ABSEIL is 3.11,
+    # see library/cmake/SfizzDeps.cmake at line 70.
+    # CMake 3.12 supports object libraries, can be used to share a single build
+    # between AU, VST2 and VST3 plugins; also to use project' HOMEPAGE_URL.
+    cmake_minimum_required(VERSION 3.12)
 endif()
 
-project (sfizz VERSION 1.2.2 LANGUAGES CXX C)
-set (PROJECT_DESCRIPTION
-    "SFZ based sampler, providing AU, LV2, PureData and VST plugins."
+# The project was splitted in 2 repositories:
+# - `sfizz` for the library, which represents the main repository reference
+# - `sfizz-ui` for UIs (plugins with a future standalone UI in mind).
+# However, to keep the original structure, we assume this as "sfizz" project,
+# containing the "libsfizz" sub project in the `library` git submodule.
+project(sfizz
+    DESCRIPTION  "SFZ sampler, providing AU, LV2, PureData and VST plugins."
+    HOMEPAGE_URL "http://sfztools.github.io/sfizz"
+    LANGUAGES    CXX C
+    VERSION      1.2.2
 )
+set(PROJECT_REPOSITORY "https://github.com/sfztools/sfizz")
+set(PROJECT_AUTHOR     "SFZTools")
+set(PROJECT_EMAIL      "paul@ferrand.cc")
+
+set(LV2_PLUGIN_VERSION_MINOR 10)
+set(LV2_PLUGIN_VERSION_MICRO 3)
+
 # External configuration CMake scripts
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};"
     "${CMAKE_CURRENT_SOURCE_DIR}/library/cmake;"
@@ -21,16 +37,21 @@ set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};"
 include(BuildType)
 include(OptionEx)
 
-option_ex(SFIZZ_AU                 "Enable AU plug-in build" APPLE)
-option_ex(SFIZZ_LV2                "Enable LV2 plug-in build" ON)
-option_ex(SFIZZ_LV2_UI             "Enable LV2 plug-in user interface" ON)
-option_ex(SFIZZ_PUREDATA           "Enable Puredata plug-in build" OFF)
+option_ex(PLUGIN_AU                "Enable AU plug-in build" APPLE)
+option_ex(PLUGIN_LV2               "Enable LV2 plug-in build" ON)
+option_ex(PLUGIN_LV2_UI            "Enable LV2 plug-in user interface" ON)
+option_ex(PLUGIN_PUREDATA          "Enable Puredata plug-in build" OFF)
+option_ex(PLUGIN_VST2              "Enable VST2 plug-in build (unsupported)" OFF)
+option_ex(PLUGIN_VST3              "Enable VST3 plug-in build" ON)
 option_ex(SFIZZ_USE_SYSTEM_LV2     "Use LV2 headers preinstalled on system" OFF)
 option_ex(SFIZZ_USE_SYSTEM_VST3SDK "Use VST3SDK source files preinstalled on system" OFF)
-option_ex(SFIZZ_VST2               "Enable VST2 plug-in build (unsupported)" OFF)
-option_ex(SFIZZ_VST                "Enable VST plug-in build" ON)
 
-set(MIDI_CC_MAX 512 CACHE STRING "Maximum amount of Control Change Messages")
+set(MIDI_CC_COUNT 512 CACHE STRING "Maximum amount of Control Change Messages")
+
+# TODO: VCPKG OR SNDFILE_STATIC?
+if(PLUGIN_LV2 AND SFIZZ_USE_VCPKG)
+    set(LV2_PLUGIN_SPDX_LICENSE_ID "LGPL-3.0-only")
+endif()
 
 # Set Windows compatibility level to 10 required by VSTGUI
 if(WIN32)
@@ -50,8 +71,8 @@ if(WIN32)
         ${PROJECT_BINARY_DIR}/innosetup.iss @ONLY)
 endif()
 
-# Put it at the end so that the vst/lv2 directories are registered
-if (NOT MSVC)
+# Leave this at the end so that the vst/lv2 directories are registered
+if(NOT MSVC)
     include(PluginsUninstall)
 endif()
 

--- a/cmake/BundleDylibs.cmake
+++ b/cmake/BundleDylibs.cmake
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
 # Dylib bundler for macOS
 # Requires the external program "dylibbundler"
 

--- a/cmake/LV2Config.cmake
+++ b/cmake/LV2Config.cmake
@@ -1,26 +1,27 @@
-# This option is for MIDI CC support in absence of host midi:binding support
-option(SFIZZ_LV2_PSA "Enable plugin-side MIDI automations" ON)
+# SPDX-License-Identifier: BSD-2-Clause
 
-# Configuration for this plugin
-# TODO: generate version from git
-set(LV2PLUGIN_VERSION_MINOR   10)
-set(LV2PLUGIN_VERSION_MICRO   3)
-set(LV2PLUGIN_NAME            "sfizz")
-set(LV2PLUGIN_COMMENT         "SFZ sampler")
-set(LV2PLUGIN_URI             "http://sfztools.github.io/sfizz")
-set(LV2PLUGIN_REPOSITORY      SFIZZ_REPOSITORY)
-set(LV2PLUGIN_AUTHOR          "SFZTools")
-set(LV2PLUGIN_EMAIL           "paul@ferrand.cc")
-if(SFIZZ_USE_VCPKG)
-    set(LV2PLUGIN_SPDX_LICENSE_ID "LGPL-3.0-only")
-else()
-    set(LV2PLUGIN_SPDX_LICENSE_ID "ISC")
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+# This option is for MIDI CC support in absence of host midi:binding support
+option(PLUGIN_LV2_PSA "Enable plugin-side MIDI automations" ON)
+
+set(LV2_PLUGIN_NAME       "${PROJECT_NAME}")
+set(LV2_PLUGIN_COMMENT    "${PROJECT_DESCRIPTION}")
+set(LV2_PLUGIN_URI        "${PROJECT_HOMEPAGE_URL}")
+set(LV2_PLUGIN_REPOSITORY "${PROJECT_REPOSITORY}")
+set(LV2_PLUGIN_AUTHOR     "${PROJECT_AUTHOR}")
+set(LV2_PLUGIN_EMAIL      "${PROJECT_EMAIL}")
+
+if(NOT LV2_PLUGIN_SPDX_LICENSE_ID)
+    set(LV2_PLUGIN_SPDX_LICENSE_ID "ISC") # default license
 endif()
 
-if(SFIZZ_LV2_UI)
-    set(LV2PLUGIN_IF_ENABLE_UI "")
+if(PLUGIN_LV2_UI)
+    set(LV2_PLUGIN_IF_ENABLE_UI "")
 else()
-    set(LV2PLUGIN_IF_ENABLE_UI "#")
+    set(LV2_PLUGIN_IF_ENABLE_UI "#")
 endif()
 
 if(WIN32)
@@ -34,43 +35,43 @@ else()
 endif()
 
 if(APPLE)
-    set(LV2PLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Audio/Plug-Ins/LV2" CACHE STRING
+    set(LV2_PLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Audio/Plug-Ins/LV2" CACHE STRING
     "Install destination for LV2 bundle [default: $ENV{HOME}/Library/Audio/Plug-Ins/LV2]")
 elseif(MSVC)
-    set(LV2PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lv2" CACHE STRING
+    set(LV2_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lv2" CACHE STRING
     "Install destination for LV2 bundle [default: ${CMAKE_INSTALL_PREFIX}/lv2]")
 else()
-    set(LV2PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/lv2" CACHE STRING
+    set(LV2_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/lv2" CACHE STRING
     "Install destination for LV2 bundle [default: ${CMAKE_INSTALL_PREFIX}/lib/lv2]")
 endif()
 
 include(StringUtility)
 
-function(sfizz_lv2_generate_controllers_ttl FILE)
-    file(WRITE "${FILE}" "# LV2 parameters for SFZ controllers
+function(generate_lv2_controllers_ttl FILE)
+    file(WRITE "${FILE}" "# LV2 parameters for MIDI CC controllers
 @prefix atom:   <http://lv2plug.in/ns/ext/atom#> .
 @prefix lv2:    <http://lv2plug.in/ns/lv2core#> .
 @prefix midi:   <http://lv2plug.in/ns/ext/midi#> .
 @prefix patch:  <http://lv2plug.in/ns/ext/patch#> .
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sfizz:  <${LV2PLUGIN_URI}#> .
+@prefix ${PROJECT_NAME}:  <${LV2_PLUGIN_URI}#> .
 ")
-    math(EXPR _j "${MIDI_CC_MAX}-1")
+    math(EXPR _j "${MIDI_CC_COUNT}-1")
     foreach(_i RANGE "${_j}")
-        if(_i LESS 128 AND SFIZZ_LV2_PSA)
+        if(_i LESS 128 AND PLUGIN_LV2_PSA)
             continue() # Don't generate automation parameters for CCs with plugin-side automation
         endif()
 
         string_left_pad(_i "${_i}" 3 0)
         file(APPEND "${FILE}" "
-sfizz:cc${_i}
+${PROJECT_NAME}:cc${_i}
   a lv2:Parameter ;
   rdfs:label \"Controller ${_i}\" ;
   rdfs:range atom:Float ;
   lv2:minimum 0.0 ;
   lv2:maximum 1.0")
 
-        if(_i LESS 128 AND NOT SFIZZ_LV2_PSA)
+        if(_i LESS 128 AND NOT PLUGIN_LV2_PSA)
             math(EXPR _digit1 "${_i}>>4")
             math(EXPR _digit2 "${_i}&15")
             string(SUBSTRING "0123456789ABCDEF" "${_digit1}" 1 _digit1)
@@ -85,22 +86,22 @@ sfizz:cc${_i}
     endforeach()
 
     file(APPEND "${FILE}" "
-<${LV2PLUGIN_URI}>
+<${LV2_PLUGIN_URI}>
   a lv2:Plugin ;
 ")
 
     file(APPEND "${FILE}" "  patch:readable")
-    if(NOT SFIZZ_LV2_PSA)
-        file(APPEND "${FILE}" " sfizz:cc000")
+    if(NOT PLUGIN_LV2_PSA)
+        file(APPEND "${FILE}" " ${PROJECT_NAME}:cc000")
         foreach(_i RANGE 1 "${_j}")
             string_left_pad(_i "${_i}" 3 0)
-            file(APPEND "${FILE}" ", sfizz:cc${_i}")
+            file(APPEND "${FILE}" ", ${PROJECT_NAME}:cc${_i}")
         endforeach()
     else()
-        file(APPEND "${FILE}" " sfizz:cc128")
+        file(APPEND "${FILE}" " ${PROJECT_NAME}:cc128")
         foreach(_i RANGE 129 "${_j}")
             string_left_pad(_i "${_i}" 3 0)
-            file(APPEND "${FILE}" ", sfizz:cc${_i}")
+            file(APPEND "${FILE}" ", ${PROJECT_NAME}:cc${_i}")
         endforeach()
     endif()
 
@@ -108,17 +109,17 @@ sfizz:cc${_i}
 ")
 
     file(APPEND "${FILE}" "  patch:writable")
-    if(NOT SFIZZ_LV2_PSA)
-        file(APPEND "${FILE}" " sfizz:cc000")
+    if(NOT PLUGIN_LV2_PSA)
+        file(APPEND "${FILE}" " ${PROJECT_NAME}:cc000")
         foreach(_i RANGE 1 "${_j}")
             string_left_pad(_i "${_i}" 3 0)
-            file(APPEND "${FILE}" ", sfizz:cc${_i}")
+            file(APPEND "${FILE}" ", ${PROJECT_NAME}:cc${_i}")
         endforeach()
     else()
-        file(APPEND "${FILE}" " sfizz:cc128")
+        file(APPEND "${FILE}" " ${PROJECT_NAME}:cc128")
         foreach(_i RANGE 129 "${_j}")
             string_left_pad(_i "${_i}" 3 0)
-            file(APPEND "${FILE}" ", sfizz:cc${_i}")
+            file(APPEND "${FILE}" ", ${PROJECT_NAME}:cc${_i}")
         endforeach()
     endif()
     file(APPEND "${FILE}" " .

--- a/cmake/MakeUninstall.cmake.in
+++ b/cmake/MakeUninstall.cmake.in
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
 if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
   message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
 endif()

--- a/cmake/PluginsUninstall.cmake
+++ b/cmake/PluginsUninstall.cmake
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
 if(NOT TARGET uninstall)
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/MakeUninstall.cmake.in"
@@ -7,13 +13,13 @@ if(NOT TARGET uninstall)
     add_custom_target(uninstall
         COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/MakeUninstall.cmake)
 
-    if(SFIZZ_LV2 AND LV2PLUGIN_INSTALL_DIR)
+    if(PLUGIN_LV2 AND LV2_PLUGIN_INSTALL_DIR)
         add_custom_command(TARGET uninstall
-            COMMAND rm -rv "${LV2PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.lv2")
+            COMMAND rm -rv "${LV2_PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.lv2")
     endif()
 
-    if(SFIZZ_VST AND VSTPLUGIN_INSTALL_DIR)
+    if(PLUGIN_VST3 AND VST3_PLUGIN_INSTALL_DIR)
         add_custom_command(TARGET uninstall
-            COMMAND rm -rv "${VSTPLUGIN_INSTALL_DIR}/${PROJECT_NAME}.vst3")
+            COMMAND rm -rv "${VST3_PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.vst3")
     endif()
 endif()

--- a/cmake/PuredataConfig.cmake
+++ b/cmake/PuredataConfig.cmake
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
 find_path(PD_INCLUDE_BASEDIR "m_pd.h" PATH_SUFFIXES "pd")
 set(PD_IMP_DEF "${PROJECT_SOURCE_DIR}/plugins/puredata/external/pd/bin/pd.def")
 
@@ -17,13 +23,13 @@ else()
 endif()
 
 if(APPLE)
-    set(PDPLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Pd" CACHE STRING
+    set(PD_PLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Pd" CACHE STRING
     "Install destination for Puredata bundle [default: $ENV{HOME}/Library/Pd]")
 elseif(MSVC)
-    set(PDPLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/Pd/extra" CACHE STRING
+    set(PD_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/Pd/extra" CACHE STRING
     "Install destination for Puredata bundle [default: ${CMAKE_INSTALL_PREFIX}/Pd/extra]")
 else()
-    set(PDPLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/pd/extra" CACHE STRING
+    set(PD_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/pd/extra" CACHE STRING
     "Install destination for Puredata bundle [default: ${CMAKE_INSTALL_PREFIX}/lib/pd/extra]")
 endif()
 

--- a/cmake/StringUtility.cmake
+++ b/cmake/StringUtility.cmake
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
 function(string_left_pad VAR INPUT LENGTH FILLCHAR)
     set(_output "${INPUT}")
     string(LENGTH "${_output}" _length)

--- a/cmake/VSTConfig.cmake
+++ b/cmake/VSTConfig.cmake
@@ -1,18 +1,24 @@
-set(VSTPLUGIN_NAME            "sfizz")
-set(VSTPLUGIN_VENDOR          "SFZTools")
-set(VSTPLUGIN_URL             "http://sfztools.github.io/sfizz")
-set(VSTPLUGIN_EMAIL           "paul@ferrand.cc")
+# SPDX-License-Identifier: BSD-2-Clause
+
+# This code is part of the sfizz library and is licensed under a BSD 2-clause
+# license. You should have receive a LICENSE.md file along with the code.
+# If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+set(VST3_PLUGIN_NAME   "${PROJECT_NAME}")
+set(VST3_PLUGIN_VENDOR "${PROJECT_AUTHOR}")
+set(VST3_PLUGIN_URL    "${PROJECT_HOMEPAGE_URL}")
+set(VST3_PLUGIN_EMAIL  "${PROJECT_EMAIL}")
 
 if(APPLE)
-    set(VSTPLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Audio/Plug-Ins/VST3" CACHE STRING
+    set(VST3_PLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Audio/Plug-Ins/VST3" CACHE STRING
     "Install destination for VST bundle [default: $ENV{HOME}/Library/Audio/Plug-Ins/VST3]")
-    set(AUPLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Audio/Plug-Ins/Components" CACHE STRING
+    set(AU_PLUGIN_INSTALL_DIR "$ENV{HOME}/Library/Audio/Plug-Ins/Components" CACHE STRING
     "Install destination for AudioUnit bundle [default: $ENV{HOME}/Library/Audio/Plug-Ins/Components]")
 elseif(MSVC)
-    set(VSTPLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/vst3" CACHE STRING
+    set(VST3_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/vst3" CACHE STRING
     "Install destination for VST bundle [default: ${CMAKE_INSTALL_PREFIX}/vst3]")
 else()
-    set(VSTPLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/vst3" CACHE STRING
+    set(VST3_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/vst3" CACHE STRING
     "Install destination for VST bundle [default: ${CMAKE_INSTALL_PREFIX}/lib/vst3]")
 endif()
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -43,18 +43,18 @@ elseif(APPLE)
 else()
 endif()
 
-if((SFIZZ_LV2 AND SFIZZ_LV2_UI) OR SFIZZ_VST OR SFIZZ_AU OR SFIZZ_VST2)
+if((PLUGIN_LV2 AND PLUGIN_LV2_UI) OR PLUGIN_VST3 OR PLUGIN_AU OR PLUGIN_VST2)
     add_subdirectory(editor)
 endif()
 
-if(SFIZZ_LV2)
+if(PLUGIN_LV2)
     add_subdirectory(lv2)
 endif()
 
-if((SFIZZ_VST OR SFIZZ_AU OR SFIZZ_VST2) AND NOT (PROJECT_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc).*"))
+if((PLUGIN_VST3 OR PLUGIN_AU OR PLUGIN_VST2) AND NOT (PROJECT_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc).*"))
     add_subdirectory(vst)
 endif()
 
-if(SFIZZ_PUREDATA)
+if(PLUGIN_PUREDATA)
     add_subdirectory(puredata)
 endif()

--- a/plugins/lv2/CMakeLists.txt
+++ b/plugins/lv2/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LV2PLUGIN_PRJ_NAME "${PROJECT_NAME}_lv2")
+set(LV2_PLUGIN_PRJ_NAME "${PROJECT_NAME}_lv2")
 
 # Set the build directory as <build_dir>/lv2/<plugin_name>.lv2/
 set(PROJECT_BINARY_DIR "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.lv2")
@@ -7,51 +7,51 @@ set(PROJECT_BINARY_DIR "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.lv2")
 include(LV2Config)
 
 # Keep non build turtle files in IDE
-set(LV2PLUGIN_TTL_SRC_FILES
+set(LV2_PLUGIN_TTL_SRC_FILES
     manifest.ttl.in
     ${PROJECT_NAME}.ttl.in
 )
-if(SFIZZ_LV2_UI)
-    list(APPEND LV2PLUGIN_TTL_SRC_FILES
+if(PLUGIN_LV2_UI)
+    list(APPEND LV2_PLUGIN_TTL_SRC_FILES
         ${PROJECT_NAME}_ui.ttl.in)
 endif()
 source_group("Turtle Files" FILES
-    ${LV2PLUGIN_TTL_SRC_FILES}
+    ${LV2_PLUGIN_TTL_SRC_FILES}
 )
-add_library(${LV2PLUGIN_PRJ_NAME} MODULE
+add_library(${LV2_PLUGIN_PRJ_NAME} MODULE
     ${PROJECT_NAME}.cpp
     ${PROJECT_NAME}_lv2_common.cpp
-    ${LV2PLUGIN_TTL_SRC_FILES})
-target_link_libraries(${LV2PLUGIN_PRJ_NAME} PRIVATE sfizz::sfizz sfizz::import sfizz::plugins-common)
+    ${LV2_PLUGIN_TTL_SRC_FILES})
+target_link_libraries(${LV2_PLUGIN_PRJ_NAME} PRIVATE sfizz::sfizz sfizz::import sfizz::plugins-common)
 
-if(SFIZZ_LV2_UI)
-    add_library(${LV2PLUGIN_PRJ_NAME}_ui MODULE
+if(PLUGIN_LV2_UI)
+    add_library(${LV2_PLUGIN_PRJ_NAME}_ui MODULE
         ${PROJECT_NAME}_ui.cpp
         ${PROJECT_NAME}_lv2_common.cpp
         vstgui_helpers.h
         vstgui_helpers.cpp)
-    target_link_libraries(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE sfizz::editor sfizz::vstgui sfizz::plugins-common)
+    target_link_libraries(${LV2_PLUGIN_PRJ_NAME}_ui PRIVATE sfizz::editor sfizz::vstgui sfizz::plugins-common)
 endif()
 
-if(SFIZZ_LV2_PSA)
-    target_compile_definitions(${LV2PLUGIN_PRJ_NAME} PRIVATE "SFIZZ_LV2_PSA=1")
-    if(SFIZZ_LV2_UI)
-        target_compile_definitions(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE "SFIZZ_LV2_PSA=1")
+if(PLUGIN_LV2_PSA)
+    target_compile_definitions(${LV2_PLUGIN_PRJ_NAME} PRIVATE "PLUGIN_LV2_PSA=1")
+    if(PLUGIN_LV2_UI)
+        target_compile_definitions(${LV2_PLUGIN_PRJ_NAME}_ui PRIVATE "PLUGIN_LV2_PSA=1")
     endif()
 endif()
 
 # Explicitely strip all symbols on Linux but lv2_descriptor()
 # MacOS linker does not support this apparently https://bugs.webkit.org/show_bug.cgi?id=144555
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_link_libraries(${LV2PLUGIN_PRJ_NAME} PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/lv2.version")
-    # target_link_libraries(${LV2PLUGIN_PRJ_NAME} "-Wl,-u,lv2_descriptor")
-    if(SFIZZ_LV2_UI)
-        target_link_libraries(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/lv2ui.version")
-        # target_link_libraries(${LV2PLUGIN_PRJ_NAME}_ui "-Wl,-u,lv2ui_descriptor")
+    target_link_libraries(${LV2_PLUGIN_PRJ_NAME} PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/lv2.version")
+    # target_link_libraries(${LV2_PLUGIN_PRJ_NAME} "-Wl,-u,lv2_descriptor")
+    if(PLUGIN_LV2_UI)
+        target_link_libraries(${LV2_PLUGIN_PRJ_NAME}_ui PRIVATE "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/lv2ui.version")
+        # target_link_libraries(${LV2_PLUGIN_PRJ_NAME}_ui "-Wl,-u,lv2ui_descriptor")
     endif()
 endif()
 
-target_include_directories(${LV2PLUGIN_PRJ_NAME} PRIVATE . external/ardour)
+target_include_directories(${LV2_PLUGIN_PRJ_NAME} PRIVATE . external/ardour)
 if(SFIZZ_USE_SYSTEM_LV2)
     find_path(LV2_INCLUDE_DIR "lv2.h")
     if(NOT LV2_INCLUDE_DIR)
@@ -60,41 +60,41 @@ if(SFIZZ_USE_SYSTEM_LV2)
         message(STATUS "Found system lv2")
     endif()
 else()
-    target_include_directories(${LV2PLUGIN_PRJ_NAME} PRIVATE vendor)
+    target_include_directories(${LV2_PLUGIN_PRJ_NAME} PRIVATE vendor)
 endif()
-sfizz_enable_lto_if_needed(${LV2PLUGIN_PRJ_NAME})
+sfizz_enable_lto_if_needed(${LV2_PLUGIN_PRJ_NAME})
 if(MINGW)
-    set_target_properties(${LV2PLUGIN_PRJ_NAME} PROPERTIES LINK_FLAGS "-static")
+    set_target_properties(${LV2_PLUGIN_PRJ_NAME} PROPERTIES LINK_FLAGS "-static")
 endif()
 
-if(SFIZZ_LV2_UI)
-    target_include_directories(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE . external/ardour)
+if(PLUGIN_LV2_UI)
+    target_include_directories(${LV2_PLUGIN_PRJ_NAME}_ui PRIVATE . external/ardour)
     if(NOT SFIZZ_USE_SYSTEM_LV2)
-        target_include_directories(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE vendor)
+        target_include_directories(${LV2_PLUGIN_PRJ_NAME}_ui PRIVATE vendor)
     endif()
-    sfizz_enable_lto_if_needed(${LV2PLUGIN_PRJ_NAME}_ui)
+    sfizz_enable_lto_if_needed(${LV2_PLUGIN_PRJ_NAME}_ui)
     if(MINGW)
-        set_target_properties(${LV2PLUGIN_PRJ_NAME}_ui PROPERTIES LINK_FLAGS "-static")
+        set_target_properties(${LV2_PLUGIN_PRJ_NAME}_ui PROPERTIES LINK_FLAGS "-static")
     endif()
 endif()
 
 # Define a preprocessor variable to indicate a build with UI enabled
-if(SFIZZ_LV2_UI)
-    target_compile_definitions(${LV2PLUGIN_PRJ_NAME} PRIVATE "SFIZZ_LV2_UI=1")
-    target_compile_definitions(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE "SFIZZ_LV2_UI=1")
+if(PLUGIN_LV2_UI)
+    target_compile_definitions(${LV2_PLUGIN_PRJ_NAME} PRIVATE "PLUGIN_LV2_UI=1")
+    target_compile_definitions(${LV2_PLUGIN_PRJ_NAME}_ui PRIVATE "PLUGIN_LV2_UI=1")
 endif()
 
 # Remove the "lib" prefix, rename the target name and build it in the .lv build dir
 # <build_dir>/lv2/<plugin_name>_lv2.<ext> to
 # <build_dir>/lv2/<plugin_name>.lv2/<plugin_name>.<ext>
-set_target_properties(${LV2PLUGIN_PRJ_NAME} PROPERTIES PREFIX "")
-set_target_properties(${LV2PLUGIN_PRJ_NAME} PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
-set_target_properties(${LV2PLUGIN_PRJ_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/Contents/Binary/$<0:>")
+set_target_properties(${LV2_PLUGIN_PRJ_NAME} PROPERTIES PREFIX "")
+set_target_properties(${LV2_PLUGIN_PRJ_NAME} PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
+set_target_properties(${LV2_PLUGIN_PRJ_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/Contents/Binary/$<0:>")
 
-if(SFIZZ_LV2_UI)
-    set_target_properties(${LV2PLUGIN_PRJ_NAME}_ui PROPERTIES PREFIX "")
-    set_target_properties(${LV2PLUGIN_PRJ_NAME}_ui PROPERTIES OUTPUT_NAME "${PROJECT_NAME}_ui")
-    set_target_properties(${LV2PLUGIN_PRJ_NAME}_ui PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/Contents/Binary/$<0:>")
+if(PLUGIN_LV2_UI)
+    set_target_properties(${LV2_PLUGIN_PRJ_NAME}_ui PROPERTIES PREFIX "")
+    set_target_properties(${LV2_PLUGIN_PRJ_NAME}_ui PROPERTIES OUTPUT_NAME "${PROJECT_NAME}_ui")
+    set_target_properties(${LV2_PLUGIN_PRJ_NAME}_ui PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/Contents/Binary/$<0:>")
 endif()
 
 # Generate *.ttl files from *.in sources,
@@ -102,13 +102,13 @@ endif()
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR})
 configure_file(manifest.ttl.in ${PROJECT_BINARY_DIR}/manifest.ttl)
 configure_file(${PROJECT_NAME}.ttl.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.ttl)
-if(SFIZZ_LV2_UI)
+if(PLUGIN_LV2_UI)
     configure_file(${PROJECT_NAME}_ui.ttl.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}_ui.ttl)
 endif()
 configure_file(LICENSE.md.in ${PROJECT_BINARY_DIR}/LICENSE.md)
 
 # Generate controllers.ttl
-sfizz_lv2_generate_controllers_ttl("${PROJECT_BINARY_DIR}/controllers.ttl")
+generate_lv2_controllers_ttl("${PROJECT_BINARY_DIR}/controllers.ttl")
 
 # Copy resource files into the bundle
 set(LV2_RESOURCES
@@ -122,24 +122,24 @@ foreach(res ${LV2_RESOURCES})
 endforeach()
 
 # Copy editor resources
-if(SFIZZ_LV2_UI)
+if(PLUGIN_LV2_UI)
     execute_process(
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/Contents/Resources")
     copy_editor_resources(
-        ${LV2PLUGIN_PRJ_NAME}_ui
+        ${LV2_PLUGIN_PRJ_NAME}_ui
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
         "${PROJECT_BINARY_DIR}/Contents/Resources")
 endif()
 
 # Installation
 if(NOT MSVC)
-    install(DIRECTORY ${PROJECT_BINARY_DIR} DESTINATION ${LV2PLUGIN_INSTALL_DIR}
+    install(DIRECTORY ${PROJECT_BINARY_DIR} DESTINATION ${LV2_PLUGIN_INSTALL_DIR}
         COMPONENT "lv2"
         USE_SOURCE_PERMISSIONS)
     bundle_dylibs(lv2
-        "${LV2PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.lv2/Contents/Binary/sfizz.so"
+        "${LV2_PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.lv2/Contents/Binary/sfizz.so"
         COMPONENT "lv2")
     bundle_dylibs(lv2-ui
-        "${LV2PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.lv2/Contents/Binary/sfizz_ui.so"
+        "${LV2_PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.lv2/Contents/Binary/sfizz_ui.so"
         COMPONENT "lv2")
 endif()

--- a/plugins/lv2/LICENSE.md.in
+++ b/plugins/lv2/LICENSE.md.in
@@ -1,7 +1,7 @@
 Most of the code in the plug comes from various examples in the LV2 distribution and
 example plugins. As such, the source code of the LV2 plugin version of `sfizz` is
 distributed under the same terms as the LV2 specification, which is the ISC license.
-Check the LICENSE.md at (@LV2PLUGIN_REPOSITORY@) file for more
+Check the LICENSE.md at (@LV2_PLUGIN_REPOSITORY@) file for more
 information about the license of the source code of the `sfizz` library and its
 contributors.
 

--- a/plugins/lv2/manifest.ttl.in
+++ b/plugins/lv2/manifest.ttl.in
@@ -2,17 +2,17 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
 
-<@LV2PLUGIN_URI@>
+<@LV2_PLUGIN_URI@>
   a lv2:Plugin ;
   lv2:binary <Contents/Binary/@PROJECT_NAME@@CMAKE_SHARED_MODULE_SUFFIX@> ;
   rdfs:seeAlso <@PROJECT_NAME@.ttl>, <controllers.ttl> .
 
-<@LV2PLUGIN_URI@-multi>
+<@LV2_PLUGIN_URI@-multi>
   a lv2:Plugin ;
   lv2:binary <Contents/Binary/@PROJECT_NAME@@CMAKE_SHARED_MODULE_SUFFIX@> ;
   rdfs:seeAlso <@PROJECT_NAME@.ttl>, <controllers.ttl> .
 
-@LV2PLUGIN_IF_ENABLE_UI@<@LV2PLUGIN_URI@#ui>
-@LV2PLUGIN_IF_ENABLE_UI@    a ui:@LV2_UI_TYPE@ ;
-@LV2PLUGIN_IF_ENABLE_UI@    ui:binary <Contents/Binary/@PROJECT_NAME@_ui@CMAKE_SHARED_MODULE_SUFFIX@> ;
-@LV2PLUGIN_IF_ENABLE_UI@    rdfs:seeAlso <@PROJECT_NAME@_ui.ttl> .
+@LV2_PLUGIN_IF_ENABLE_UI@<@LV2_PLUGIN_URI@#ui>
+@LV2_PLUGIN_IF_ENABLE_UI@    a ui:@LV2_UI_TYPE@ ;
+@LV2_PLUGIN_IF_ENABLE_UI@    ui:binary <Contents/Binary/@PROJECT_NAME@_ui@CMAKE_SHARED_MODULE_SUFFIX@> ;
+@LV2_PLUGIN_IF_ENABLE_UI@    rdfs:seeAlso <@PROJECT_NAME@_ui.ttl> .

--- a/plugins/lv2/sfizz.cpp
+++ b/plugins/lv2/sfizz.cpp
@@ -662,7 +662,7 @@ instantiate(const LV2_Descriptor *descriptor,
     self->text_description[0] = 0;
     self->resend_description = false;
 
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
     if (self->multi_out)
         self->rms_follower.setNumOutputs(MULTI_OUTPUT_COUNT);
     else
@@ -693,7 +693,7 @@ activate(LV2_Handle instance)
     sfizz_set_samples_per_block(self->synth, self->max_block_size);
     sfizz_set_sample_rate(self->synth, self->sample_rate);
     self->must_update_midnam.store(1);
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
     self->rms_follower.init(self->sample_rate);
 #endif
 }
@@ -761,7 +761,7 @@ sfizz_lv2_send_controller(sfizz_plugin_t *self, LV2_URID verb_uri, unsigned cc, 
         lv2_atom_forge_pop(forge, &frame);
 }
 
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
 static void
 sfizz_lv2_send_levels(sfizz_plugin_t *self, const float* levels, uint32_t num_levels)
 {
@@ -890,7 +890,7 @@ sfizz_lv2_process_midi_event(sfizz_plugin_t *self, const LV2_Atom_Event *ev)
 
 // Note(jpc) CC must be mapped by host, not handled here.
 //           See LV2 midi:binding.
-#if defined(SFIZZ_LV2_PSA)
+#if defined(PLUGIN_LV2_PSA)
             switch (cc)
             {
             default:
@@ -1276,7 +1276,7 @@ run(LV2_Handle instance, uint32_t sample_count)
 
     spin_mutex_unlock(self->synth_mutex);
 
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
     if (self->ui_active)
     {
         if (self->multi_out) {

--- a/plugins/lv2/sfizz.ttl.in
+++ b/plugins/lv2/sfizz.ttl.in
@@ -23,69 +23,69 @@
 midnam:interface a lv2:ExtensionData .
 midnam:update a lv2:Feature .
 
-<@LV2PLUGIN_URI@#stereo_output>
+<@LV2_PLUGIN_URI@#stereo_output>
   a pg:StereoGroup, pg:OutputGroup ;
   lv2:symbol "stereo_output" ;
   lv2:name "Stereo output",
     "Sortie stéréo"@fr ,
     "Uscita stereo"@it .
 
-<@LV2PLUGIN_URI@#config>
+<@LV2_PLUGIN_URI@#config>
   a pg:Group ;
   lv2:symbol "config" ;
   lv2:name "Configuration",
     "Configuration"@fr ,
     "Impostazioni"@it .
 
-<@LV2PLUGIN_URI@#tuning>
+<@LV2_PLUGIN_URI@#tuning>
   a pg:Group ;
   lv2:symbol "tuning" ;
   lv2:name "Tuning",
     "Accordage"@fr ,
     "Accordatura"@it .
 
-<@LV2PLUGIN_URI@#status>
+<@LV2_PLUGIN_URI@#status>
   a pg:Group ;
   lv2:symbol "status" ;
   lv2:name "status",
     "Statut"@fr .
 
-<@LV2PLUGIN_URI@:sfzfile>
+<@LV2_PLUGIN_URI@:sfzfile>
   a lv2:Parameter ;
   rdfs:label "SFZ file",
     "Fichier SFZ"@fr ,
     "File SFZ"@it ;
   rdfs:range atom:Path .
 
-<@LV2PLUGIN_URI@:tuningfile>
+<@LV2_PLUGIN_URI@:tuningfile>
   a lv2:Parameter ;
-  pg:group <@LV2PLUGIN_URI@#tuning> ;
+  pg:group <@LV2_PLUGIN_URI@#tuning> ;
   rdfs:label "Scala file",
     "Fichier Scala"@fr ,
     "File Scala"@it ;
   rdfs:range atom:Path .
 
-<@LV2PLUGIN_URI@:description>
+<@LV2_PLUGIN_URI@:description>
   a lv2:Parameter ;
   rdfs:label "Instrument description" ;
   rdfs:range atom:String .
 
-<@LV2PLUGIN_URI@>
+<@LV2_PLUGIN_URI@>
   a doap:Project, lv2:Plugin, lv2:InstrumentPlugin ;
 
-  doap:name "@LV2PLUGIN_NAME@" ;
-  doap:license <https://spdx.org/licenses/@LV2PLUGIN_SPDX_LICENSE_ID@> ;
+  doap:name "@LV2_PLUGIN_NAME@" ;
+  doap:license <https://spdx.org/licenses/@LV2_PLUGIN_SPDX_LICENSE_ID@> ;
   doap:maintainer [
-    foaf:name     "@LV2PLUGIN_AUTHOR@" ;
-    foaf:homepage <@LV2PLUGIN_URI@> ;
-    foaf:mbox     <mailto:@LV2PLUGIN_EMAIL@> ;
+    foaf:name     "@LV2_PLUGIN_AUTHOR@" ;
+    foaf:homepage <@LV2_PLUGIN_URI@> ;
+    foaf:mbox     <mailto:@LV2_PLUGIN_EMAIL@> ;
   ] ;
-  rdfs:comment "@LV2PLUGIN_COMMENT@",
+  rdfs:comment "@LV2_PLUGIN_COMMENT@",
     "Échantillonneur SFZ"@fr ,
     "Campionatore SFZ"@it ;
 
-  lv2:minorVersion @LV2PLUGIN_VERSION_MINOR@ ;
-  lv2:microVersion @LV2PLUGIN_VERSION_MICRO@ ;
+  lv2:minorVersion @LV2_PLUGIN_VERSION_MINOR@ ;
+  lv2:microVersion @LV2_PLUGIN_VERSION_MICRO@ ;
 
   lv2:requiredFeature urid:map, bufsize:boundedBlockLength, work:schedule ;
   lv2:optionalFeature lv2:hardRTCapable, opts:options, state:mapPath, state:freePath ;
@@ -97,18 +97,18 @@ midnam:update a lv2:Feature .
   opts:supportedOption param:sampleRate ;
   opts:supportedOption bufsize:maxBlockLength, bufsize:nominalBlockLength ;
 
-  @LV2PLUGIN_IF_ENABLE_UI@ui:ui <@LV2PLUGIN_URI@#ui> ;
+  @LV2_PLUGIN_IF_ENABLE_UI@ui:ui <@LV2_PLUGIN_URI@#ui> ;
 
-  patch:writable <@LV2PLUGIN_URI@:sfzfile> ,
-                 <@LV2PLUGIN_URI@:tuningfile> ;
-  patch:readable <@LV2PLUGIN_URI@:description> ;
+  patch:writable <@LV2_PLUGIN_URI@:sfzfile> ,
+                 <@LV2_PLUGIN_URI@:tuningfile> ;
+  patch:readable <@LV2_PLUGIN_URI@:description> ;
 
-  pg:mainOutput <@LV2PLUGIN_URI@#stereo_output> ;
+  pg:mainOutput <@LV2_PLUGIN_URI@#stereo_output> ;
 
   lv2:port [
     a lv2:InputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
-    atom:supports patch:Message, midi:MidiEvent, time:Position, <@LV2PLUGIN_URI@:OSCBlob>, <@LV2PLUGIN_URI@:Notify> ;
+    atom:supports patch:Message, midi:MidiEvent, time:Position, <@LV2_PLUGIN_URI@:OSCBlob>, <@LV2_PLUGIN_URI@:Notify> ;
     lv2:designation lv2:control ;
     lv2:index 0 ;
     lv2:symbol "control" ;
@@ -118,7 +118,7 @@ midnam:update a lv2:Feature .
   ] , [
     a lv2:OutputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
-    atom:supports patch:Message, <@LV2PLUGIN_URI@:OSCBlob> ;
+    atom:supports patch:Message, <@LV2_PLUGIN_URI@:OSCBlob> ;
     lv2:designation lv2:control ;
     lv2:index 1 ;
     lv2:symbol "automate" ;
@@ -132,7 +132,7 @@ midnam:update a lv2:Feature .
     lv2:name "Left Output",
       "Sortie gauche"@fr ,
       "Uscita Sinistra"@it ;
-    pg:group <@LV2PLUGIN_URI@#stereo_output> ;
+    pg:group <@LV2_PLUGIN_URI@#stereo_output> ;
     lv2:designation pg:left
   ] , [
     a lv2:AudioPort, lv2:OutputPort ;
@@ -141,7 +141,7 @@ midnam:update a lv2:Feature .
     lv2:name "Right Output",
       "Sortie droite"@fr ,
       "Uscita Destra"@it ;
-    pg:group <@LV2PLUGIN_URI@#stereo_output> ;
+    pg:group <@LV2_PLUGIN_URI@#stereo_output> ;
     lv2:designation pg:right
   ] , [
     a lv2:InputPort, lv2:ControlPort ;
@@ -159,7 +159,7 @@ midnam:update a lv2:Feature .
     lv2:name "Polyphony",
       "Polyphonie"@fr ,
       "Polifonia"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty pprop:notAutomatic ;
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
@@ -204,7 +204,7 @@ midnam:update a lv2:Feature .
     lv2:name "Oversampling factor",
       "Facteur de suréchantillonnage"@fr ,
       "Fattore Sovracampionamento"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty pprop:notAutomatic ;
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
@@ -239,7 +239,7 @@ midnam:update a lv2:Feature .
     lv2:name "Preload size",
       "Taille préchargée"@fr ,
       "Grandezza Precaricamento"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty pprop:notAutomatic ;
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
@@ -294,7 +294,7 @@ midnam:update a lv2:Feature .
     lv2:name "Scala root key",
       "Tonalité de base Scala"@fr ,
       "Tonalità di base Scala"@it ;
-    pg:group <@LV2PLUGIN_URI@#tuning> ;
+    pg:group <@LV2_PLUGIN_URI@#tuning> ;
     lv2:portProperty lv2:integer ;
     lv2:default 60 ;
     lv2:minimum 0 ;
@@ -307,7 +307,7 @@ midnam:update a lv2:Feature .
     lv2:name "Tuning frequency",
       "Fréquence d'accordage"@fr ,
       "Frequenza di accordatura"@it ;
-    pg:group <@LV2PLUGIN_URI@#tuning> ;
+    pg:group <@LV2_PLUGIN_URI@#tuning> ;
     lv2:default 440.0 ;
     lv2:minimum 300.0 ;
     lv2:maximum 500.0 ;
@@ -319,7 +319,7 @@ midnam:update a lv2:Feature .
     lv2:name "Stretched tuning",
       "Accordage étiré"@fr ,
       "Tensione di accordatura"@it ;
-    pg:group <@LV2PLUGIN_URI@#tuning> ;
+    pg:group <@LV2_PLUGIN_URI@#tuning> ;
     lv2:default 0.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 1.0 ;
@@ -331,7 +331,7 @@ midnam:update a lv2:Feature .
     lv2:name "Sample quality",
       "Qualité des échantillons"@fr ,
       "Qualità del campione"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 2.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 10.0
@@ -342,7 +342,7 @@ midnam:update a lv2:Feature .
     lv2:name "Oscillator quality",
       "Qualité des oscillateurs"@fr ,
       "Qualità dell'oscillatore"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 1.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 3.0
@@ -352,7 +352,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "active_voices" ;
     lv2:name "Active voices",
       "Voix utilisées"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -363,7 +363,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_curves" ;
     lv2:name "Number of curves",
       "Nombre de courbes"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -374,7 +374,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_masters" ;
     lv2:name "Number of masters",
       "Nombre de maîtres"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -385,7 +385,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_groups" ;
     lv2:name "Number of groups",
       "Nombre de groupes"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -396,7 +396,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_regions" ;
     lv2:name "Number of regions",
       "Nombre de régions"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -407,7 +407,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_samples" ;
     lv2:name "Number of samples",
       "Nombre d'échantillons"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -418,7 +418,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "freewheeling_sample_quality" ;
     lv2:name "Freewheeling Sample quality",
       "Qualité des échantillons en roue libre"@fr;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 10.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 10.0
@@ -428,7 +428,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "freewheeling_oscillator_quality" ;
     lv2:name "Freewheeling Oscillator quality",
       "Qualité des oscillateurs en roue libre"@fr ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 3.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 3.0
@@ -437,7 +437,7 @@ midnam:update a lv2:Feature .
     lv2:index 22 ;
     lv2:symbol "sustain_cancels_release" ;
     lv2:name "Sustain cancels release";
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty lv2:toggled ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -446,22 +446,22 @@ midnam:update a lv2:Feature .
 
   rdfs:seeAlso <controllers.ttl> .
 
-<@LV2PLUGIN_URI@-multi>
+<@LV2_PLUGIN_URI@-multi>
   a doap:Project, lv2:Plugin, lv2:InstrumentPlugin ;
 
-  doap:name "@LV2PLUGIN_NAME@-multi" ;
-  doap:license <https://spdx.org/licenses/@LV2PLUGIN_SPDX_LICENSE_ID@> ;
+  doap:name "@LV2_PLUGIN_NAME@-multi" ;
+  doap:license <https://spdx.org/licenses/@LV2_PLUGIN_SPDX_LICENSE_ID@> ;
   doap:maintainer [
-    foaf:name     "@LV2PLUGIN_AUTHOR@" ;
-    foaf:homepage <@LV2PLUGIN_URI@> ;
-    foaf:mbox     <mailto:@LV2PLUGIN_EMAIL@> ;
+    foaf:name     "@LV2_PLUGIN_AUTHOR@" ;
+    foaf:homepage <@LV2_PLUGIN_URI@> ;
+    foaf:mbox     <mailto:@LV2_PLUGIN_EMAIL@> ;
   ] ;
-  rdfs:comment "@LV2PLUGIN_COMMENT@",
+  rdfs:comment "@LV2_PLUGIN_COMMENT@",
     "Échantillonneur SFZ"@fr ,
     "Campionatore SFZ"@it ;
 
-  lv2:minorVersion @LV2PLUGIN_VERSION_MINOR@ ;
-  lv2:microVersion @LV2PLUGIN_VERSION_MICRO@ ;
+  lv2:minorVersion @LV2_PLUGIN_VERSION_MINOR@ ;
+  lv2:microVersion @LV2_PLUGIN_VERSION_MICRO@ ;
 
   lv2:requiredFeature urid:map, bufsize:boundedBlockLength, work:schedule ;
   lv2:optionalFeature lv2:hardRTCapable, opts:options, state:mapPath, state:freePath ;
@@ -473,18 +473,18 @@ midnam:update a lv2:Feature .
   opts:supportedOption param:sampleRate ;
   opts:supportedOption bufsize:maxBlockLength, bufsize:nominalBlockLength ;
 
-  @LV2PLUGIN_IF_ENABLE_UI@ui:ui <@LV2PLUGIN_URI@#ui> ;
+  @LV2_PLUGIN_IF_ENABLE_UI@ui:ui <@LV2_PLUGIN_URI@#ui> ;
 
-  patch:writable <@LV2PLUGIN_URI@:sfzfile> ,
-                 <@LV2PLUGIN_URI@:tuningfile> ;
-  patch:readable <@LV2PLUGIN_URI@:description> ;
+  patch:writable <@LV2_PLUGIN_URI@:sfzfile> ,
+                 <@LV2_PLUGIN_URI@:tuningfile> ;
+  patch:readable <@LV2_PLUGIN_URI@:description> ;
 
-  pg:mainOutput <@LV2PLUGIN_URI@#stereo_output> ;
+  pg:mainOutput <@LV2_PLUGIN_URI@#stereo_output> ;
 
   lv2:port [
     a lv2:InputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
-    atom:supports patch:Message, midi:MidiEvent, time:Position, <@LV2PLUGIN_URI@:OSCBlob>, <@LV2PLUGIN_URI@:Notify> ;
+    atom:supports patch:Message, midi:MidiEvent, time:Position, <@LV2_PLUGIN_URI@:OSCBlob>, <@LV2_PLUGIN_URI@:Notify> ;
     lv2:designation lv2:control ;
     lv2:index 0 ;
     lv2:symbol "control" ;
@@ -494,7 +494,7 @@ midnam:update a lv2:Feature .
   ] , [
     a lv2:OutputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
-    atom:supports patch:Message, <@LV2PLUGIN_URI@:OSCBlob> ;
+    atom:supports patch:Message, <@LV2_PLUGIN_URI@:OSCBlob> ;
     lv2:designation lv2:control ;
     lv2:index 1 ;
     lv2:symbol "automate" ;
@@ -629,7 +629,7 @@ midnam:update a lv2:Feature .
     lv2:name "Polyphony",
       "Polyphonie"@fr ,
       "Polifonia"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty pprop:notAutomatic ;
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
@@ -674,7 +674,7 @@ midnam:update a lv2:Feature .
     lv2:name "Oversampling factor",
       "Facteur de suréchantillonnage"@fr ,
       "Fattore Sovracampionamento"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty pprop:notAutomatic ;
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
@@ -709,7 +709,7 @@ midnam:update a lv2:Feature .
     lv2:name "Preload size",
       "Taille préchargée"@fr ,
       "Grandezza Precaricamento"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty pprop:notAutomatic ;
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
@@ -764,7 +764,7 @@ midnam:update a lv2:Feature .
     lv2:name "Scala root key",
       "Tonalité de base Scala"@fr ,
       "Tonalità di base Scala"@it ;
-    pg:group <@LV2PLUGIN_URI@#tuning> ;
+    pg:group <@LV2_PLUGIN_URI@#tuning> ;
     lv2:portProperty lv2:integer ;
     lv2:default 60 ;
     lv2:minimum 0 ;
@@ -777,7 +777,7 @@ midnam:update a lv2:Feature .
     lv2:name "Tuning frequency",
       "Fréquence d'accordage"@fr ,
       "Frequenza di accordatura"@it ;
-    pg:group <@LV2PLUGIN_URI@#tuning> ;
+    pg:group <@LV2_PLUGIN_URI@#tuning> ;
     lv2:default 440.0 ;
     lv2:minimum 300.0 ;
     lv2:maximum 500.0 ;
@@ -789,7 +789,7 @@ midnam:update a lv2:Feature .
     lv2:name "Stretched tuning",
       "Accordage étiré"@fr ,
       "Tensione di accordatura"@it ;
-    pg:group <@LV2PLUGIN_URI@#tuning> ;
+    pg:group <@LV2_PLUGIN_URI@#tuning> ;
     lv2:default 0.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 1.0 ;
@@ -801,7 +801,7 @@ midnam:update a lv2:Feature .
     lv2:name "Sample quality",
       "Qualité des échantillons"@fr ,
       "Qualità del campione"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 2.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 10.0
@@ -812,7 +812,7 @@ midnam:update a lv2:Feature .
     lv2:name "Oscillator quality",
       "Qualité des oscillateurs"@fr ,
       "Qualità dell'oscillatore"@it ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 1.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 3.0
@@ -822,7 +822,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "active_voices" ;
     lv2:name "Active voices",
       "Voix utilisées"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -833,7 +833,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_curves" ;
     lv2:name "Number of curves",
       "Nombre de courbes"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -844,7 +844,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_masters" ;
     lv2:name "Number of masters",
       "Nombre de maîtres"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -855,7 +855,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_groups" ;
     lv2:name "Number of groups",
       "Nombre de groupes"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -866,7 +866,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_regions" ;
     lv2:name "Number of regions",
       "Nombre de régions"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -877,7 +877,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "num_samples" ;
     lv2:name "Number of samples",
       "Nombre d'échantillons"@fr ;
-    pg:group <@LV2PLUGIN_URI@#status> ;
+    pg:group <@LV2_PLUGIN_URI@#status> ;
     lv2:portProperty lv2:integer ;
     lv2:default 0 ;
     lv2:minimum 0 ;
@@ -888,7 +888,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "freewheeling_sample_quality" ;
     lv2:name "Freewheeling Sample quality",
       "Qualité des échantillons en roue libre"@fr;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 10.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 10.0
@@ -898,7 +898,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "freewheeling_oscillator_quality" ;
     lv2:name "Freewheeling Oscillator quality",
       "Qualité des oscillateurs en roue libre"@fr ;
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:default 3.0 ;
     lv2:minimum 0.0 ;
     lv2:maximum 3.0
@@ -907,7 +907,7 @@ midnam:update a lv2:Feature .
     lv2:index 36 ;
     lv2:symbol "sustain_cancels_release" ;
     lv2:name "Sustain cancels release";
-    pg:group <@LV2PLUGIN_URI@#config> ;
+    pg:group <@LV2_PLUGIN_URI@#config> ;
     lv2:portProperty lv2:toggled ;
     lv2:default 0 ;
     lv2:minimum 0 ;

--- a/plugins/lv2/sfizz_lv2.h
+++ b/plugins/lv2/sfizz_lv2.h
@@ -147,7 +147,7 @@ bool sfizz_lv2_fetch_description(
  */
 int sfizz_lv2_get_num_outputs(sfizz_plugin_t *self);
 
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
 void sfizz_lv2_set_ui_active(sfizz_plugin_t *self, bool ui_active);
 #endif
 

--- a/plugins/lv2/sfizz_lv2_common.cpp
+++ b/plugins/lv2/sfizz_lv2_common.cpp
@@ -39,7 +39,7 @@ int sfizz_lv2_get_num_outputs(sfizz_plugin_t *self)
     return 2;
 }
 
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
 void sfizz_lv2_set_ui_active(sfizz_plugin_t *self, bool ui_active)
 {
     self->ui_active = ui_active;

--- a/plugins/lv2/sfizz_lv2_plugin.h
+++ b/plugins/lv2/sfizz_lv2_plugin.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "sfizz_lv2.h"
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
 #include "plugin/RMSFollower.h"
 #endif
 #include <spin_mutex.h>
@@ -155,7 +155,7 @@ struct sfizz_plugin_t
     // OSC
     uint8_t osc_temp[OSC_TEMP_SIZE] {};
 
-#if defined(SFIZZ_LV2_UI)
+#if defined(PLUGIN_LV2_UI)
     // UI
     volatile bool ui_active = false;
     RMSFollower rms_follower;

--- a/plugins/lv2/sfizz_ui.cpp
+++ b/plugins/lv2/sfizz_ui.cpp
@@ -805,7 +805,7 @@ void sfizz_ui_t::uiSendValue(EditId id, const EditValue& v)
     default:
         if (editIdIsCC(id)) {
             int cc = ccForEditId(id);
-#if defined(SFIZZ_LV2_PSA)
+#if defined(PLUGIN_LV2_PSA)
             if (cc >= 0 && cc < 128) {
                 // Send MIDI message
                 uint8_t msg[3];

--- a/plugins/lv2/sfizz_ui.ttl.in
+++ b/plugins/lv2/sfizz_ui.ttl.in
@@ -3,7 +3,7 @@
 @prefix ui:   <http://lv2plug.in/ns/extensions/ui#> .
 @prefix urid: <http://lv2plug.in/ns/ext/urid#> .
 
-<@LV2PLUGIN_URI@#ui>
+<@LV2_PLUGIN_URI@#ui>
     lv2:extensionData ui:idleInterface ;
     lv2:extensionData ui:showInterface ;
     lv2:requiredFeature ui:idleInterface ;

--- a/plugins/puredata/CMakeLists.txt
+++ b/plugins/puredata/CMakeLists.txt
@@ -25,7 +25,7 @@ endfunction()
 
 add_pd_external(sfizz_puredata "sfizz_puredata.c")
 target_compile_definitions(sfizz_puredata PRIVATE
-    "MIDI_CC_MAX=${MIDI_CC_MAX}"
+    "MIDI_CC_COUNT=${MIDI_CC_COUNT}"
     "SFIZZ_VERSION=\"${CMAKE_PROJECT_VERSION}\"")
 target_link_libraries(sfizz_puredata PRIVATE sfizz::import sfizz::sfizz)
 
@@ -48,10 +48,10 @@ copy_puredata_resources(sfizz_puredata
 
 # Installation
 if(NOT MSVC)
-    install(DIRECTORY "${PUREDATA_BINARY_DIR}" DESTINATION "${PDPLUGIN_INSTALL_DIR}"
+    install(DIRECTORY "${PUREDATA_BINARY_DIR}" DESTINATION "${PD_PLUGIN_INSTALL_DIR}"
         COMPONENT "puredata"
         USE_SOURCE_PERMISSIONS)
     bundle_dylibs(puredata
-        "${PDPLUGIN_INSTALL_DIR}/sfizz/sfizz${PUREDATA_SUFFIX}"
+        "${PD_PLUGIN_INSTALL_DIR}/sfizz/sfizz${PUREDATA_SUFFIX}"
         COMPONENT "puredata")
 endif()

--- a/plugins/puredata/sfizz_puredata.c
+++ b/plugins/puredata/sfizz_puredata.c
@@ -238,7 +238,7 @@ static void sfizz_tilde_reload(t_sfizz_tilde* self, t_float value)
 static void sfizz_tilde_hdcc(t_sfizz_tilde* self, t_float f1, t_float f2)
 {
     int cc = (int)f1;
-    if (cc < 0 || cc >= MIDI_CC_MAX)
+    if (cc < 0 || cc >= MIDI_CC_COUNT)
         return;
     sfizz_automate_hdcc(self->synth, 0, (int)cc, clamp01(f2));
 }

--- a/plugins/vst/CMakeLists.txt
+++ b/plugins/vst/CMakeLists.txt
@@ -67,109 +67,109 @@ add_library(sfizz::vst3-core ALIAS sfizz-vst3-core)
 
 # --- VST3 plugin --- #
 
-if(SFIZZ_VST)
-    set(VSTPLUGIN_PRJ_NAME "${PROJECT_NAME}_vst3")
-    set(VSTPLUGIN_BUNDLE_NAME "${PROJECT_NAME}.vst3")
+if(PLUGIN_VST3)
+    set(VST3_PLUGIN_PRJ_NAME "${PROJECT_NAME}_vst3")
+    set(VST3_PLUGIN_BUNDLE_NAME "${PROJECT_NAME}.vst3")
 
-    add_library(${VSTPLUGIN_PRJ_NAME} MODULE "VstPluginFactory.cpp")
+    add_library(${VST3_PLUGIN_PRJ_NAME} MODULE "VstPluginFactory.cpp")
     if(WIN32)
-        target_sources(${VSTPLUGIN_PRJ_NAME} PRIVATE vst3.def)
+        target_sources(${VST3_PLUGIN_PRJ_NAME} PRIVATE vst3.def)
     endif()
-    target_include_directories(${VSTPLUGIN_PRJ_NAME}
+    target_include_directories(${VST3_PLUGIN_PRJ_NAME}
         PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
-    target_link_libraries(${VSTPLUGIN_PRJ_NAME}
+    target_link_libraries(${VST3_PLUGIN_PRJ_NAME}
         PRIVATE sfizz-vst3-core)
-    set_target_properties(${VSTPLUGIN_PRJ_NAME} PROPERTIES
+    set_target_properties(${VST3_PLUGIN_PRJ_NAME} PROPERTIES
         OUTPUT_NAME "${PROJECT_NAME}"
         PREFIX "")
 
-    plugin_add_vst3sdk(${VSTPLUGIN_PRJ_NAME})
-    plugin_add_vstgui(${VSTPLUGIN_PRJ_NAME})
+    plugin_add_vst3sdk(${VST3_PLUGIN_PRJ_NAME})
+    plugin_add_vstgui(${VST3_PLUGIN_PRJ_NAME})
 
     if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-        target_link_libraries(${VSTPLUGIN_PRJ_NAME} PRIVATE
+        target_link_libraries(${VST3_PLUGIN_PRJ_NAME} PRIVATE
             "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/vst3.version")
     endif()
-    sfizz_enable_lto_if_needed(${VSTPLUGIN_PRJ_NAME})
+    sfizz_enable_lto_if_needed(${VST3_PLUGIN_PRJ_NAME})
     if(MINGW)
-        set_target_properties(${VSTPLUGIN_PRJ_NAME} PROPERTIES LINK_FLAGS "-static")
+        set_target_properties(${VST3_PLUGIN_PRJ_NAME} PROPERTIES LINK_FLAGS "-static")
     endif()
 
     # Create the bundle(see "VST 3 Locations / Format")
     execute_process(
-        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/Resources")
     copy_editor_resources(
-        ${VSTPLUGIN_PRJ_NAME}
+        ${VST3_PLUGIN_PRJ_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
-        "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
+        "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/Resources")
     if(WIN32)
-        set_target_properties(${VSTPLUGIN_PRJ_NAME} PROPERTIES
+        set_target_properties(${VST3_PLUGIN_PRJ_NAME} PROPERTIES
             SUFFIX ".vst3"
-            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/${VST3_PACKAGE_ARCHITECTURE}-win/$<0:>")
+            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/${VST3_PACKAGE_ARCHITECTURE}-win/$<0:>")
         file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/win/Plugin.ico"
             "${CMAKE_CURRENT_SOURCE_DIR}/win/desktop.ini"
-            DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}")
+            DESTINATION "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}")
     elseif(APPLE)
-        set_target_properties(${VSTPLUGIN_PRJ_NAME} PROPERTIES
+        set_target_properties(${VST3_PLUGIN_PRJ_NAME} PROPERTIES
             SUFFIX ""
-            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/MacOS/$<0:>")
+            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/MacOS/$<0:>")
         file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/mac/PkgInfo"
-            DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents")
+            DESTINATION "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents")
         set(SFIZZ_VST3_BUNDLE_EXECUTABLE "${PROJECT_NAME}")
         set(SFIZZ_VST3_BUNDLE_VERSION "${PROJECT_VERSION}")
         configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/Info.vst3.plist"
-            "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Info.plist" @ONLY)
+            "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/Info.plist" @ONLY)
     else()
-        set_target_properties(${VSTPLUGIN_PRJ_NAME} PROPERTIES
-            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/${VST3_PACKAGE_ARCHITECTURE}-linux/$<0:>")
+        set_target_properties(${VST3_PLUGIN_PRJ_NAME} PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/${VST3_PACKAGE_ARCHITECTURE}-linux/$<0:>")
     endif()
 
     # Copy the license
     if(APPLE)
         # on macOS, files are not permitted at the bundle root, during code signing
         file(COPY "gpl-3.0.txt"
-            DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/SharedSupport/License")
+            DESTINATION "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/SharedSupport/License")
     else()
         file(COPY "gpl-3.0.txt"
-            DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}")
+            DESTINATION "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}")
     endif()
 
     # To help debugging the link only
     if(FALSE)
-        target_link_options(${VSTPLUGIN_PRJ_NAME} PRIVATE "-Wl,-no-undefined")
+        target_link_options(${VST3_PLUGIN_PRJ_NAME} PRIVATE "-Wl,-no-undefined")
     endif()
 
     # Installation
     if(NOT MSVC)
-        install(DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}"
-            DESTINATION "${VSTPLUGIN_INSTALL_DIR}"
+        install(DIRECTORY "${PROJECT_BINARY_DIR}/${VST3_PLUGIN_BUNDLE_NAME}"
+            DESTINATION "${VST3_PLUGIN_INSTALL_DIR}"
             COMPONENT "vst"
             USE_SOURCE_PERMISSIONS)
         bundle_dylibs(vst
-            "${VSTPLUGIN_INSTALL_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/MacOS/sfizz"
+            "${VST3_PLUGIN_INSTALL_DIR}/${VST3_PLUGIN_BUNDLE_NAME}/Contents/MacOS/sfizz"
             COMPONENT "vst")
     endif()
 endif()
 
 # --- Audio Unit wrapper --- #
 
-if(SFIZZ_AU AND NOT APPLE)
+if(PLUGIN_AU AND NOT APPLE)
     message(WARNING "Audio Unit is available only for macOS builds")
-elseif(SFIZZ_AU)
-    set(AUPLUGIN_PRJ_NAME "${PROJECT_NAME}_au")
-    set(AUPLUGIN_BUNDLE_NAME "${PROJECT_NAME}.component")
+elseif(PLUGIN_AU)
+    set(AU_PLUGIN_PRJ_NAME "${PROJECT_NAME}_au")
+    set(AU_PLUGIN_BUNDLE_NAME "${PROJECT_NAME}.component")
 
-    add_library(${AUPLUGIN_PRJ_NAME} MODULE
+    add_library(${AU_PLUGIN_PRJ_NAME} MODULE
         "VstPluginFactory.cpp"
         "${AUWRAPPER_BASEDIR}/aucarbonview.mm"
         "${AUWRAPPER_BASEDIR}/aucocoaview.mm"
         "${AUWRAPPER_BASEDIR}/ausdk.mm"
         "${AUWRAPPER_BASEDIR}/auwrapper.mm"
         "${AUWRAPPER_BASEDIR}/NSDataIBStream.mm")
-    target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE
+    target_include_directories(${AU_PLUGIN_PRJ_NAME} PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}"
         "${VST3SDK_BASEDIR}")
-    target_link_libraries(${AUPLUGIN_PRJ_NAME} PRIVATE
+    target_link_libraries(${AU_PLUGIN_PRJ_NAME} PRIVATE
         "${APPLE_FOUNDATION_LIBRARY}"
         "${APPLE_COCOA_LIBRARY}"
         "${APPLE_CARBON_LIBRARY}"
@@ -178,14 +178,14 @@ elseif(SFIZZ_AU)
         "${APPLE_COREAUDIO_LIBRARY}"
         "${APPLE_COREMIDI_LIBRARY}")
 
-    target_link_libraries(${AUPLUGIN_PRJ_NAME}
+    target_link_libraries(${AU_PLUGIN_PRJ_NAME}
         PRIVATE sfizz-vst3-core)
-    set_target_properties(${AUPLUGIN_PRJ_NAME} PROPERTIES
+    set_target_properties(${AU_PLUGIN_PRJ_NAME} PROPERTIES
         OUTPUT_NAME "${PROJECT_NAME}"
         PREFIX "")
 
-    plugin_add_vst3sdk(${AUPLUGIN_PRJ_NAME})
-    plugin_add_vstgui(${AUPLUGIN_PRJ_NAME})
+    plugin_add_vst3sdk(${AU_PLUGIN_PRJ_NAME})
+    plugin_add_vstgui(${AU_PLUGIN_PRJ_NAME})
 
     # Get Core Audio utility classes if missing
     set(CA_UTILITY_BASEDIR
@@ -215,7 +215,7 @@ elseif(SFIZZ_AU)
     endif()
 
     # Add Core Audio utility classes
-    target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE
+    target_include_directories(${AU_PLUGIN_PRJ_NAME} PRIVATE
         "${CA_UTILITY_BASEDIR}/CoreAudio"
         "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits"
         "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/AUBase"
@@ -223,29 +223,29 @@ elseif(SFIZZ_AU)
         "${CA_UTILITY_BASEDIR}/CoreAudio/PublicUtility")
 
     # Add VST hosting classes
-    target_link_libraries(${AUPLUGIN_PRJ_NAME} PRIVATE vst3sdk_hosting)
+    target_link_libraries(${AU_PLUGIN_PRJ_NAME} PRIVATE vst3sdk_hosting)
 
     # Add generated source
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
-    target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/include")
+    target_include_directories(${AU_PLUGIN_PRJ_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/include")
     string(TIMESTAMP SFIZZ_AU_CLASS_PREFIX_NUMBER "%s" UTC)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/aucocoaclassprefix.h"
         "#define SMTG_AU_NAMESPACE SMTGAUCocoa${SFIZZ_AU_CLASS_PREFIX_NUMBER}_")
 
-    sfizz_enable_lto_if_needed(${AUPLUGIN_PRJ_NAME})
+    sfizz_enable_lto_if_needed(${AU_PLUGIN_PRJ_NAME})
 
     # Create the bundle
     execute_process(
-        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents/Resources")
     copy_editor_resources(
-        ${AUPLUGIN_PRJ_NAME}
+        ${AU_PLUGIN_PRJ_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
-        "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
-    set_target_properties(${AUPLUGIN_PRJ_NAME} PROPERTIES
+        "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents/Resources")
+    set_target_properties(${AU_PLUGIN_PRJ_NAME} PROPERTIES
         SUFFIX ""
-        LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/MacOS/$<0:>")
+        LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents/MacOS/$<0:>")
     file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/mac/PkgInfo"
-        DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents")
+        DESTINATION "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents")
     set(SFIZZ_AU_BUNDLE_EXECUTABLE "${PROJECT_NAME}")
     set(SFIZZ_AU_BUNDLE_VERSION "${PROJECT_VERSION}")
     set(SFIZZ_AU_BUNDLE_IDENTIFIER "tools.sfz.sfizz.au")
@@ -260,10 +260,10 @@ elseif(SFIZZ_AU)
         OUTPUT_VARIABLE SFIZZ_AU_HEXADECIMAL_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/Info.au.plist"
-        "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Info.plist" @ONLY)
+        "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents/Info.plist" @ONLY)
 
     file(COPY "gpl-3.0.txt"
-        DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/SharedSupport/License")
+        DESTINATION "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents/SharedSupport/License")
 
     # Add the resource fork
     if(FALSE)
@@ -272,7 +272,7 @@ elseif(SFIZZ_AU)
         file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
         configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/audiounitconfig.h.in"
             "${CMAKE_CURRENT_BINARY_DIR}/include/audiounitconfig.h" @ONLY)
-        add_custom_command(TARGET ${AUPLUGIN_PRJ_NAME} POST_BUILD COMMAND
+        add_custom_command(TARGET ${AU_PLUGIN_PRJ_NAME} POST_BUILD COMMAND
             "${OSX_REZ_COMMAND}"
             "-d" "SystemSevenOrLater=1"
             "-script" "Roman"
@@ -284,28 +284,28 @@ elseif(SFIZZ_AU)
             "-I" "/System/Library/Frameworks/AudioUnit.framework/Versions/A/Headers/"
             "-I" "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/AUBase"
             "-I" "${CMAKE_CURRENT_BINARY_DIR}/include" # generated audiounitconfig.h
-            "-o" "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/${PROJECT_NAME}.rsrc"
+            "-o" "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents/Resources/${PROJECT_NAME}.rsrc"
             "-useDF"
             "${AUWRAPPER_BASEDIR}/auresource.r")
     endif()
 
     # Installation
-    if(AUPLUGIN_INSTALL_DIR)
-        install(DIRECTORY "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}"
-            DESTINATION "${AUPLUGIN_INSTALL_DIR}"
+    if(AU_PLUGIN_INSTALL_DIR)
+        install(DIRECTORY "${PROJECT_BINARY_DIR}/${AU_PLUGIN_BUNDLE_NAME}"
+            DESTINATION "${AU_PLUGIN_INSTALL_DIR}"
             COMPONENT "au"
             USE_SOURCE_PERMISSIONS)
         bundle_dylibs(au
-            "${AUPLUGIN_INSTALL_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/MacOS/sfizz"
+            "${AU_PLUGIN_INSTALL_DIR}/${AU_PLUGIN_BUNDLE_NAME}/Contents/MacOS/sfizz"
             COMPONENT "au")
     endif()
 endif()
 
 # --- VST2 wrapper --- #
 
-if(SFIZZ_VST2)
-    set(VST2PLUGIN_PRJ_NAME "${PROJECT_NAME}_vst2")
-    set(VST2PLUGIN_BUNDLE_NAME "${PROJECT_NAME}.vst2")
+if(PLUGIN_VST2)
+    set(VST2_PLUGIN_PRJ_NAME "${PROJECT_NAME}_vst2")
+    set(VST2_PLUGIN_BUNDLE_NAME "${PROJECT_NAME}.vst2")
 
     set(VST2SDK_BASEDIR "${CMAKE_CURRENT_SOURCE_DIR}/external/vstsdk2.4")
     set(VST2WRAPPER_BASEDIR "${CMAKE_CURRENT_SOURCE_DIR}/external/VST_SDK/VST3_SDK/public.sdk/source/vst/vst2wrapper")
@@ -314,7 +314,7 @@ if(SFIZZ_VST2)
         message(FATAL_ERROR "VST SDK 2.4 is missing. Make it available in the following folder: ${VST2SDK_BASEDIR}")
     endif()
 
-    add_library(${VST2PLUGIN_PRJ_NAME} MODULE
+    add_library(${VST2_PLUGIN_PRJ_NAME} MODULE
         "VstPluginFactory.cpp"
         "Vst2PluginFactory.cpp"
         "Vst2PluginEntry.c"
@@ -322,54 +322,54 @@ if(SFIZZ_VST2)
         "${VST2WRAPPER_BASEDIR}/../basewrapper/basewrapper.cpp"
         "${VST2SDK_BASEDIR}/public.sdk/source/vst2.x/audioeffect.cpp"
         "${VST2SDK_BASEDIR}/public.sdk/source/vst2.x/audioeffectx.cpp")
-    target_include_directories(${VST2PLUGIN_PRJ_NAME} PRIVATE
+    target_include_directories(${VST2_PLUGIN_PRJ_NAME} PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}"
         "${VST2SDK_BASEDIR}")
 
     if(NOT WIN32)
-        target_compile_definitions(${VST2PLUGIN_PRJ_NAME} PRIVATE "__cdecl=")
+        target_compile_definitions(${VST2_PLUGIN_PRJ_NAME} PRIVATE "__cdecl=")
     endif()
 
-    target_link_libraries(${VST2PLUGIN_PRJ_NAME}
+    target_link_libraries(${VST2_PLUGIN_PRJ_NAME}
         PRIVATE sfizz-vst3-core)
-    set_target_properties(${VST2PLUGIN_PRJ_NAME} PROPERTIES
+    set_target_properties(${VST2_PLUGIN_PRJ_NAME} PROPERTIES
         OUTPUT_NAME "${PROJECT_NAME}"
         PREFIX "")
 
-    plugin_add_vst3sdk(${VST2PLUGIN_PRJ_NAME})
-    plugin_add_vstgui(${VST2PLUGIN_PRJ_NAME})
+    plugin_add_vst3sdk(${VST2_PLUGIN_PRJ_NAME})
+    plugin_add_vstgui(${VST2_PLUGIN_PRJ_NAME})
 
     # Add VST hosting classes
-    target_link_libraries(${VST2PLUGIN_PRJ_NAME} PRIVATE vst3sdk_hosting)
+    target_link_libraries(${VST2_PLUGIN_PRJ_NAME} PRIVATE vst3sdk_hosting)
 
-    sfizz_enable_lto_if_needed(${VST2PLUGIN_PRJ_NAME})
+    sfizz_enable_lto_if_needed(${VST2_PLUGIN_PRJ_NAME})
 
     # Create the bundle
     execute_process(
-        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}/Contents/Resources")
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${VST2_PLUGIN_BUNDLE_NAME}/Contents/Resources")
     copy_editor_resources(
-        ${VST2PLUGIN_PRJ_NAME}
+        ${VST2_PLUGIN_PRJ_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
-        "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}/Contents/Resources")
-    set_target_properties(${VST2PLUGIN_PRJ_NAME} PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}/Contents/Binary/$<0:>")
+        "${PROJECT_BINARY_DIR}/${VST2_PLUGIN_BUNDLE_NAME}/Contents/Resources")
+    set_target_properties(${VST2_PLUGIN_PRJ_NAME} PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VST2_PLUGIN_BUNDLE_NAME}/Contents/Binary/$<0:>")
 
     file(COPY "gpl-3.0.txt"
-        DESTINATION "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}")
+        DESTINATION "${PROJECT_BINARY_DIR}/${VST2_PLUGIN_BUNDLE_NAME}")
 
     if(MINGW)
-        set_target_properties(${VST2PLUGIN_PRJ_NAME} PROPERTIES LINK_FLAGS "-static")
+        set_target_properties(${VST2_PLUGIN_PRJ_NAME} PROPERTIES LINK_FLAGS "-static")
     endif()
 
     # Installation
-    if(VST2PLUGIN_INSTALL_DIR)
-        install(DIRECTORY "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}"
-            DESTINATION "${VST2PLUGIN_INSTALL_DIR}"
+    if(VST2_PLUGIN_INSTALL_DIR)
+        install(DIRECTORY "${PROJECT_BINARY_DIR}/${VST2_PLUGIN_BUNDLE_NAME}"
+            DESTINATION "${VST2_PLUGIN_INSTALL_DIR}"
             COMPONENT "vst2"
             USE_SOURCE_PERMISSIONS)
         if(APPLE)
             bundle_dylibs(vst2
-                "${VST2PLUGIN_INSTALL_DIR}/${VST2PLUGIN_BUNDLE_NAME}/Contents/Binary/sfizz.${CMAKE_SHARED_MODULE_SUFFIX}"
+                "${VST2_PLUGIN_INSTALL_DIR}/${VST2_PLUGIN_BUNDLE_NAME}/Contents/Binary/sfizz.${CMAKE_SHARED_MODULE_SUFFIX}"
                 COMPONENT "vst2")
         endif()
     endif()

--- a/plugins/vst/VstPluginDefs.h.in
+++ b/plugins/vst/VstPluginDefs.h.in
@@ -4,8 +4,8 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-#define VSTPLUGIN_NAME "@VSTPLUGIN_NAME@"
-#define VSTPLUGIN_VENDOR "@VSTPLUGIN_VENDOR@"
-#define VSTPLUGIN_URL "@VSTPLUGIN_URL@"
-#define VSTPLUGIN_EMAIL "@VSTPLUGIN_EMAIL@"
-#define VSTPLUGIN_VERSION "@PROJECT_VERSION@"
+#define VST3_PLUGIN_NAME "@VST3_PLUGIN_NAME@"
+#define VST3_PLUGIN_VENDOR "@VST3_PLUGIN_VENDOR@"
+#define VST3_PLUGIN_URL "@VST3_PLUGIN_URL@"
+#define VST3_PLUGIN_EMAIL "@VST3_PLUGIN_EMAIL@"
+#define VST3_PLUGIN_VERSION "@PROJECT_VERSION@"

--- a/plugins/vst/VstPluginFactory.cpp
+++ b/plugins/vst/VstPluginFactory.cpp
@@ -15,37 +15,37 @@ class SfizzVstProcessor;
 class SfizzVstProcessorMulti;
 class SfizzVstController;
 
-BEGIN_FACTORY_DEF(VSTPLUGIN_VENDOR,
-                  VSTPLUGIN_URL,
-                  "mailto:" VSTPLUGIN_EMAIL)
+BEGIN_FACTORY_DEF(VST3_PLUGIN_VENDOR,
+                  VST3_PLUGIN_URL,
+                  "mailto:" VST3_PLUGIN_EMAIL)
 
 DEF_CLASS2 (INLINE_UID_FROM_FUID(SfizzVstProcessor_cid),
             PClassInfo::kManyInstances,
             kVstAudioEffectClass,
-            VSTPLUGIN_NAME,
+            VST3_PLUGIN_NAME,
             Vst::kDistributable,
             Vst::PlugType::kInstrumentSynth,
-            VSTPLUGIN_VERSION,
+            VST3_PLUGIN_VERSION,
             kVstVersionString,
             createInstance<SfizzVstProcessor>)
 
 DEF_CLASS2 (INLINE_UID_FROM_FUID(SfizzVstProcessorMulti_cid),
             PClassInfo::kManyInstances,
             kVstAudioEffectClass,
-            VSTPLUGIN_NAME "-multi",
+            VST3_PLUGIN_NAME "-multi",
             Vst::kDistributable,
             Vst::PlugType::kInstrumentSynth,
-            VSTPLUGIN_VERSION,
+            VST3_PLUGIN_VERSION,
             kVstVersionString,
             createInstance<SfizzVstProcessorMulti>)
 
 DEF_CLASS2 (INLINE_UID_FROM_FUID(SfizzVstController_cid),
             PClassInfo::kManyInstances,
             kVstComponentControllerClass,
-            VSTPLUGIN_NAME,
+            VST3_PLUGIN_NAME,
             0,						// not used here
             "",						// not used here
-            VSTPLUGIN_VERSION,
+            VST3_PLUGIN_VERSION,
             kVstVersionString,
             createInstance<SfizzVstController>)
 


### PR DESCRIPTION
- Rename some SFIZZ_ prefixed definitions where possible to permit some modules to be generic and be reused in other projects, keep project' information in the same place and more explicit
- Fixed non-compliant code formatting