### PR TITLE
Add ability for universal plugin (intel/arm) build on macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,14 @@ if(WIN32)
     add_compile_definitions(_WIN32_WINNT=0x0A00)
 endif()
 
+option(SFIZZ_MAC_UNIVERSAL_BINARY "Build universal binary for mac" OFF)
+
+if (APPLE)
+    if (SFIZZ_MAC_UNIVERSAL_BINARY)
+        set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE INTERNAL "")
+    endif()
+endif()
+
 # Override sfizz CXX standard since vstgui requires 17 anyway
 if (PLUGIN_AU OR PLUGIN_LV2_UI OR PLUGIN_VST3 OR PLUGIN_VST2)
     set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to be used")


### PR DESCRIPTION
Added new cmake option SFIZZ_MAC_UNIVERSAL_BINARY for enabling universal x86_64/arm64 build of plugins. It currently defaults to OFF, but you should set up the CI and release setups to enable it.

PLEASE NOTE, this needs the latest develop of sfizz that includes the fix for universal building.