### PR TITLE
Fix #95: replace `\` with `/` on Windows when saving file paths.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,10 +188,10 @@ jobs:
         sudo killall -9 AudioComponentRegistrar
         auval -v aumu samp Sfzt
     - name: Package bundles
-      # if: ${{ github.ref_type == 'tag' }}
+      if: github.ref_type == 'tag' || github.event_name == 'pull_request'
       run: ./scripts/package-osx-bundles.sh
     - name: Create installer
-      # if: ${{ github.ref_type == 'tag' }}
+      if: github.ref_type == 'tag' || github.event_name == 'pull_request'
       working-directory: ${{ github.workspace }}/build
       run: |
         options=(
@@ -203,7 +203,7 @@ jobs:
         )
         productbuild "${options[@]}"
     - name: Upload
-      # if: ${{ github.ref_type == 'tag' }}
+      if: github.ref_type == 'tag' || github.event_name == 'pull_request'
       uses: actions/upload-artifact@v3
       with:
         name: macOS package
@@ -267,11 +267,11 @@ jobs:
       working-directory: ${{ github.workspace }}/build
       run: pluginval --validate-in-process --validate sfizz.vst3
     - name: Create installer
-      # if: ${{ github.ref_type == 'tag' }}
+      if: github.ref_type == 'tag' || github.event_name == 'pull_request'
       working-directory: ${{ github.workspace }}/build
       run: iscc /O"." /F"${{ env.install_name }}" /dARCH="${{ matrix.platform }}" innosetup.iss
     - name: Upload
-      # if: ${{ github.ref_type == 'tag' }}
+      if: github.ref_type == 'tag' || github.event_name == 'pull_request'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.pkg_platform }} installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,10 +188,10 @@ jobs:
         sudo killall -9 AudioComponentRegistrar
         auval -v aumu samp Sfzt
     - name: Package bundles
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       run: ./scripts/package-osx-bundles.sh
     - name: Create installer
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       working-directory: ${{ github.workspace }}/build
       run: |
         options=(
@@ -203,7 +203,7 @@ jobs:
         )
         productbuild "${options[@]}"
     - name: Upload
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       uses: actions/upload-artifact@v3
       with:
         name: macOS package
@@ -267,11 +267,11 @@ jobs:
       working-directory: ${{ github.workspace }}/build
       run: pluginval --validate-in-process --validate sfizz.vst3
     - name: Create installer
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       working-directory: ${{ github.workspace }}/build
       run: iscc /O"." /F"${{ env.install_name }}" /dARCH="${{ matrix.platform }}" innosetup.iss
     - name: Upload
-      if: ${{ github.ref_type == 'tag' }}
+      # if: ${{ github.ref_type == 'tag' }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.pkg_platform }} installer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,16 +129,28 @@ jobs:
   build_for_macos:
     name: macOS 11
     runs-on: macos-11
-    env:
-      install_name: "sfizz-${{ github.ref_name }}-macos"
     steps:
+    - name: Update bash
+      run: brew install bash
+    - name: Set install_name
+      run: |
+        ghref=${{ github.ref_name }}
+        echo "install_name=sfizz-${ghref//'/'/'-'}-macos" >> "$GITHUB_ENV"
+    - name: Show summary
+      run: |
+        echo "install_name: ${{ env.install_name }}"
+        echo "BASH_VERSION: $BASH_VERSION"
+        system_profiler SPSoftwareDataType
+        cmake --version
+        gcc -v
+        xcodebuild -version
+    - name: Install dependencies
+      if: ${{ github.ref_type == 'branch' }}
+      run: brew install abseil
     - name: Checkout
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: Install dependencies
-      if: ${{ github.ref_type == 'branch' }}
-      run: brew install abseil
     - name: Configure CMake
       run: |
         options=(
@@ -223,9 +235,14 @@ jobs:
           pkg_platform: Win64
           release_arch: x64
           bits: 64
-    env:
-      install_name: sfizz-${{ github.ref_name }}-win${{ matrix.bits }}
     steps:
+    - name: Set install name
+      run: |
+        $stripped_name="${{ github.ref_name }}".replace('/', '-')
+        echo "install_name=sfizz-$stripped_name-win${{ matrix.bits }}" >> "${env:GITHUB_ENV}"
+    - name: Show summary
+      run: |
+        echo "install_name: $env:install_name"
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/plugins/common/plugin/FileTrie.cpp
+++ b/plugins/common/plugin/FileTrie.cpp
@@ -97,6 +97,10 @@ size_t FileTrieBuilder::ensureDirectory(const fs::path& dirPath)
         fs::path parentPath = dirPath.parent_path();
         if (parentPath != dirPath)
             ent.parent = ensureDirectory(parentPath);
+        else
+            // On Windows, (--dirPath.end()) would be `\\` but `parent_path` and `dirPath`
+            // would both be `C:\\` so we update the name to match.
+            ent.name = dirPath.u8string();
     }
 
     size_t dirIndex = trie.entries_.size();

--- a/plugins/common/plugin/NativeHelpers.cpp
+++ b/plugins/common/plugin/NativeHelpers.cpp
@@ -12,6 +12,28 @@
 #include <cstdlib>
 #include <fstream>
 
+
+#if defined(_WIN32)
+const fs::path toPlatformAgnosticPath(std::string& filePath)
+{
+    return fs::u8path(filePath.replace(filePath.begin(), filePath.end(), '\\', '/'));
+}
+const fs::path fromPlatformAgnosticPath(const char *filePath)
+{
+    std::string p{filePath};
+    return fs::u8path(p.replace(p.begin(), p.end(), '/', '\\'));
+}
+#else
+const fs::path toPlatformAgnosticPath(std::string& filePath)
+{
+    return fs::u8path(filePath);
+}
+const fs::path fromPlatformAgnosticPath(const char *filePath)
+{
+    return fs::u8path(filePath);
+}
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #include <shlobj.h>

--- a/plugins/common/plugin/NativeHelpers.cpp
+++ b/plugins/common/plugin/NativeHelpers.cpp
@@ -16,12 +16,14 @@
 #if defined(_WIN32)
 const fs::path toPlatformAgnosticPath(std::string& filePath)
 {
-    return fs::u8path(filePath.replace(filePath.begin(), filePath.end(), '\\', '/'));
+    std::replace(filePath.begin(), filePath.end(), '\\', '/');
+    return fs::u8path(filePath);
 }
 const fs::path fromPlatformAgnosticPath(const char *filePath)
 {
-    std::string p{filePath};
-    return fs::u8path(p.replace(p.begin(), p.end(), '/', '\\'));
+    std::string p { filePath };
+    std::replace(p.begin(), p.end(), '/', '\\');
+    return fs::u8path(p);
 }
 #else
 const fs::path toPlatformAgnosticPath(std::string& filePath)

--- a/plugins/common/plugin/NativeHelpers.h
+++ b/plugins/common/plugin/NativeHelpers.h
@@ -13,6 +13,9 @@
 
 const fs::path& getUserDocumentsDirectory();
 
+const fs::path toPlatformAgnosticPath(std::string& filePath);
+const fs::path fromPlatformAgnosticPath(const char *filePath);
+
 #if !defined(_WIN32) && !defined(__APPLE__)
 const fs::path& getUserHomeDirectory();
 const fs::path& getXdgConfigHome();

--- a/plugins/vst/SfizzVstProcessor.cpp
+++ b/plugins/vst/SfizzVstProcessor.cpp
@@ -12,6 +12,7 @@
 #include "sfizz/import/sfizz_import.h"
 #include "plugin/SfizzFileScan.h"
 #include "plugin/InstrumentDescription.h"
+#include "plugin/NativeHelpers.h"
 #include "base/source/fstreamer.h"
 #include "base/source/updatehandler.h"
 #include "pluginterfaces/vst/ivstevents.h"
@@ -178,7 +179,8 @@ tresult PLUGIN_API SfizzVstProcessor::setState(IBStream* stream)
         if (statePath->empty())
             continue;
 
-        fs::path pathOrig = fs::u8path(*statePath);
+        // save file path in platform-agnostic way. See sfizz-ui issue #95
+        fs::path pathOrig = toPlatformAgnosticPath(*statePath);
         std::error_code ec;
         if (fs::is_regular_file(pathOrig, ec))
             continue;

--- a/plugins/vst/SfizzVstState.cpp
+++ b/plugins/vst/SfizzVstState.cpp
@@ -22,7 +22,7 @@ tresult SfizzVstState::load(IBStream* state)
         return kResultFalse;
 
     if (const char* str = s.readStr8())
-        sfzFile = fromPlatformAgnosticPath(str);
+        sfzFile = fromPlatformAgnosticPath(str).string();
     else
         return kResultFalse;
 
@@ -42,7 +42,7 @@ tresult SfizzVstState::load(IBStream* state)
 
     if (version >= 1) {
         if (const char* str = s.readStr8())
-            scalaFile = fromPlatformAgnosticPath(str);
+            scalaFile = fromPlatformAgnosticPath(str).string();
         else
             return kResultFalse;
 

--- a/plugins/vst/SfizzVstState.cpp
+++ b/plugins/vst/SfizzVstState.cpp
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SfizzVstState.h"
+#include "plugin/NativeHelpers.h"
 #include <sfizz.h>
 #include <mutex>
 #include <cstring>
@@ -21,7 +22,7 @@ tresult SfizzVstState::load(IBStream* state)
         return kResultFalse;
 
     if (const char* str = s.readStr8())
-        sfzFile = str;
+        sfzFile = fromPlatformAgnosticPath(str);
     else
         return kResultFalse;
 
@@ -41,7 +42,7 @@ tresult SfizzVstState::load(IBStream* state)
 
     if (version >= 1) {
         if (const char* str = s.readStr8())
-            scalaFile = str;
+            scalaFile = fromPlatformAgnosticPath(str);
         else
             return kResultFalse;
 


### PR DESCRIPTION
... and do vice versa on restore.

This is an alternative fix for #95 to  #100 (so if we apply #100 this fix is going to be unnecessary).

I haven't tested it on Windows yet, so I'm going to ask someone on Discord.