### PR TITLE
Fixed Git build version in the about dialog 

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -38,6 +38,24 @@ target_link_libraries(plugins-common
     PRIVATE sfizz::internal sfizz::sfizz)
 add_library(sfizz::plugins-common ALIAS plugins-common)
 
+add_custom_target(generate_plugins_git_build_id
+    COMMAND
+        "${CMAKE_COMMAND}"
+        "-DSOURCE_DIR=${PROJECT_SOURCE_DIR}"
+        "-DOUTPUT_FILE=${PROJECT_BINARY_DIR}/git-build-id/PluginGitBuildId.c"
+        "-DPREFIX=Plugin"
+        "-P" "${PROJECT_SOURCE_DIR}/library/cmake/GitBuildID.cmake"
+    BYPRODUCTS
+        "${PROJECT_BINARY_DIR}/git-build-id/PluginGitBuildId.c"
+)
+add_library(plugins_git_build_id STATIC EXCLUDE_FROM_ALL
+    "${PROJECT_SOURCE_DIR}/plugins/git-build-id/PluginGitBuildId.h"
+    "${PROJECT_BINARY_DIR}/git-build-id/PluginGitBuildId.c"
+)
+target_include_directories(plugins_git_build_id PUBLIC "${PROJECT_SOURCE_DIR}/plugins/git-build-id")
+add_dependencies(plugins_git_build_id generate_plugins_git_build_id)
+add_library(plugins::git_build_id ALIAS plugins_git_build_id)
+
 # Link system dependencies
 if(WIN32)
 elseif(ANDROID)

--- a/plugins/editor/CMakeLists.txt
+++ b/plugins/editor/CMakeLists.txt
@@ -99,9 +99,12 @@ add_library(sfizz_editor STATIC EXCLUDE_FROM_ALL
 )
 add_library(sfizz::editor ALIAS sfizz_editor)
 
-target_include_directories(sfizz_editor PUBLIC "src")
+target_include_directories(sfizz_editor PUBLIC src)
 target_link_libraries(sfizz_editor PUBLIC sfizz::messaging sfizz::plugins-common)
-target_link_libraries(sfizz_editor PRIVATE sfizz::vstgui)
+target_link_libraries(sfizz_editor PRIVATE
+    sfizz::vstgui
+    plugins::git_build_id
+)
 target_compile_definitions(sfizz_editor PRIVATE
     "SFIZZ_VERSION=\"${CMAKE_PROJECT_VERSION}\"")
 if(APPLE)
@@ -137,9 +140,13 @@ else()
     target_include_directories(sfizz_editor PRIVATE ${sfizz-gio_INCLUDE_DIRS})
     target_link_libraries(sfizz_editor PRIVATE ${sfizz-gio_LIBRARIES})
 endif()
-target_link_libraries(sfizz_editor PRIVATE sfizz::colorspaces sfizz::stb_image
-    sfizz::bit_array sfizz::filesystem sfizz::pugixml)
-
+target_link_libraries(sfizz_editor PRIVATE
+    sfizz::colorspaces
+    sfizz::stb_image
+    sfizz::bit_array
+    sfizz::filesystem
+    sfizz::pugixml
+)
 # layout tool
 if(NOT CMAKE_CROSSCOMPILING)
     set(LAYOUTMAKER_SOURCES
@@ -161,6 +168,3 @@ if(NOT CMAKE_CROSSCOMPILING)
             DEPENDS layout-maker "${CMAKE_CURRENT_SOURCE_DIR}/layout/${_layout}.fl")
     endforeach()
 endif()
-
-# Git build identifier
-target_link_libraries(sfizz_editor PRIVATE sfizz-git-build-id)

--- a/plugins/editor/src/editor/DlgAbout.cpp
+++ b/plugins/editor/src/editor/DlgAbout.cpp
@@ -7,7 +7,7 @@
 #include "DlgAbout.h"
 #include "GUIComponents.h"
 #include "GUIDefs.h"
-#include "GitBuildId.h"
+#include "PluginGitBuildId.h"
 #include "NativeHelpers.h"
 
 #include "utility/vstgui_before.h"
@@ -53,8 +53,8 @@ SAboutDialog::SAboutDialog(const CRect& bounds)
 
             const char* version = SFIZZ_VERSION;
             std::string versionBuf;
-            if (GitBuildId[0]) {
-                versionBuf = absl::StrCat(SFIZZ_VERSION ".", GitBuildId);
+            if (PluginGitBuildId[0]) {
+                versionBuf = absl::StrCat(SFIZZ_VERSION ".", PluginGitBuildId);
                 version = versionBuf.c_str();
             }
 #if 0

--- a/plugins/git-build-id/PluginGitBuildId.h
+++ b/plugins/git-build-id/PluginGitBuildId.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief Short identifier of the current head commit.
+ * This generated identifier is empty if the build is not from a Git repository.
+ */
+extern const char* PluginGitBuildId;
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/plugins/puredata/CMakeLists.txt
+++ b/plugins/puredata/CMakeLists.txt
@@ -26,9 +26,13 @@ endfunction()
 add_pd_external(sfizz_puredata "sfizz_puredata.c")
 target_compile_definitions(sfizz_puredata PRIVATE
     "MIDI_CC_COUNT=${MIDI_CC_COUNT}"
-    "SFIZZ_VERSION=\"${CMAKE_PROJECT_VERSION}\"")
-target_link_libraries(sfizz_puredata PRIVATE sfizz::import sfizz::sfizz)
-
+    "SFIZZ_VERSION=\"${CMAKE_PROJECT_VERSION}\""
+)
+target_link_libraries(sfizz_puredata PRIVATE
+    sfizz::import
+    sfizz::sfizz
+    plugins::git_build_id
+)
 set_target_properties(sfizz_puredata PROPERTIES
     OUTPUT_NAME "sfizz"
     LIBRARY_OUTPUT_DIRECTORY "${PUREDATA_BINARY_DIR}/$<0:>")
@@ -37,9 +41,6 @@ if(MINGW)
     set_property(TARGET sfizz_puredata APPEND_STRING
         PROPERTY LINK_FLAGS " -static")
 endif()
-
-# Git build identifier
-target_link_libraries(sfizz_puredata PRIVATE sfizz-git-build-id)
 
 # Copy resources
 copy_puredata_resources(sfizz_puredata

--- a/plugins/puredata/sfizz_puredata.c
+++ b/plugins/puredata/sfizz_puredata.c
@@ -4,7 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-#include "GitBuildId.h"
+#include "PluginGitBuildId.h"
 #include <m_pd.h>
 #include <sfizz.h>
 #include <sfizz/import/sfizz_import.h>
@@ -294,8 +294,8 @@ __attribute__((visibility("default")))
 #endif
 void sfizz_setup()
 {
-    if (GitBuildId[0])
-        post("sfizz external for Puredata, version '%s.%s'", SFIZZ_VERSION, GitBuildId);
+    if (PluginGitBuildId[0])
+        post("sfizz external for Puredata, version '%s.%s'", SFIZZ_VERSION, PluginGitBuildId);
     else
         post("sfizz external for Puredata, version '%s'", SFIZZ_VERSION);
 


### PR DESCRIPTION
previously was displayed the library build version, which is no more the same
after the library and plugins repository split.
