### PR TITLE
fix UI crasher caused by negative (unexpected) colorspace vrgb components.

### DIFF
--- a/plugins/editor/src/editor/ColorHelpers.cpp
+++ b/plugins/editor/src/editor/ColorHelpers.cpp
@@ -19,9 +19,9 @@ SColorRGB::SColorRGB(const SColorHCY &hcy)
 {
     ColorSpaces::vec3 vhcy{{hcy.h, hcy.c, hcy.y}};
     ColorSpaces::vec3 vrgb = ColorSpaces::hcy_to_rgb(vhcy);
-    r = vrgb[0];
-    g = vrgb[1];
-    b = vrgb[2];
+    r = fmax(0.0f, vrgb[0]);
+    g = fmax(0.0f, vrgb[1]);
+    b = fmax(0.0f, vrgb[2]);
     a = hcy.a;
 }
 


### PR DESCRIPTION
The following code somehow results in negative r value component:

```c++
    ColorSpaces::vec3 vrgb = ColorSpaces::hcy_to_rgb(vhcy);
```

... while hcy_to_rgb() itself calculates `vec3` (`std::array<float,3>`) as expected. Negative components then leads to runtime crash.

Considering that the function might return negative values anyway, filter out those negative values here at SColorRGB constructor to sanitize inputs.