### PR TITLE
Allocate cc_current on the stack

### DIFF
--- a/plugins/lv2/sfizz.cpp
+++ b/plugins/lv2/sfizz.cpp
@@ -644,7 +644,6 @@ instantiate(const LV2_Descriptor *descriptor,
     }
 
     self->ccmap = sfizz_lv2_ccmap_create(self->map);
-    self->cc_current = new float[sfz::config::numCCs]();
 
     self->synth = sfizz_create_synth();
     self->client = sfizz_create_client(self);
@@ -681,7 +680,6 @@ cleanup(LV2_Handle instance)
     spin_mutex_destroy(self->synth_mutex);
     sfizz_delete_client(self->client);
     sfizz_free(self->synth);
-    delete[] self->cc_current;
     sfizz_lv2_ccmap_free(self->ccmap);
     delete self;
 }

--- a/plugins/lv2/sfizz_lv2_plugin.h
+++ b/plugins/lv2/sfizz_lv2_plugin.h
@@ -17,6 +17,7 @@
 #include <absl/types/optional.h>
 #include <atomic>
 #include <mutex>
+#include "sfizz/Config.h"
 
 #define DEFAULT_SCALA_FILE  "Contents/Resources/DefaultScale.scl"
 #define DEFAULT_SFZ_FILE    "Contents/Resources/DefaultInstrument.sfz"
@@ -138,7 +139,7 @@ struct sfizz_plugin_t
 
     // Current CC values in the synth (synchronized by `synth_mutex`)
     // updated by hdcc or file load
-    float *cc_current {};
+    float cc_current[sfz::config::numCCs] = {};
     volatile bool resync_cc { false };
 
     // Timing data


### PR DESCRIPTION
Current implementation has a bug where self->cc_current and self->cc_resync are initialized to some random value during load of some SFZ files e.g. https://github.com/sfzinstruments/SMDrums:

```
sfizz_lv2_update_sfz_info access self->cc_current=0x5647690 resync_cc=1 
sfizz_lv2_update_sfz_info access self->cc_current=0x5647690 resync_cc=1 
sfizz_lv2_update_sfz_info access self->cc_current=0x5647690 resync_cc=1 
sfizz_lv2_update_sfz_info access self->cc_current=0x5647690 resync_cc=1 
sfizz_lv2_update_sfz_info access self->cc_current=0x203a303031202d90 resync_cc=67
```

This causes a SEGFAULT when trying to update CC in sfizz_lv2_update_sfz_info

I wasn't able to find the root cause, but a dumb fix like this eliminates the issue.
As plugin serialization state doesn't change, this is backward- and forward-compatible